### PR TITLE
Fix: Resolve flake8 issues in optical_controller.py

### DIFF
--- a/optical_controller/optical_controller.py
+++ b/optical_controller/optical_controller.py
@@ -2,9 +2,10 @@
 """
 optical_controller.py
 
-Módulo que simula el procesamiento óptico para el sistema Watchers. Captura una "imagen" del estado global,
-la procesa (reflejo) y genera una señal de retroalimentación. Proporciona un servicio REST para integrarse
-con otros componentes del sistema.
+Módulo que simula el procesamiento óptico para el sistema Watchers.
+Captura una "imagen" del estado global, la procesa (reflejo) y genera una
+señal de retroalimentación. Proporciona un servicio REST para integrarse con
+otros componentes del sistema.
 
 Funcionalidades:
 - Captura de imagen a partir de una matriz de estado.
@@ -18,7 +19,7 @@ import numpy as np
 import cv2
 import logging
 from flask import Flask, request, jsonify
-from typing import List, Dict, Any
+from typing import List
 
 # Configuración centralizada
 logging.basicConfig(
@@ -33,19 +34,22 @@ logger = logging.getLogger("optical_controller")
 
 app = Flask(__name__)
 
+
 def capturar_imagen(matriz_estado: List[List[float]]) -> np.ndarray:
     """
     Captura una imagen simulada a partir de una matriz de estado.
-    
+
     Args:
         matriz_estado (List[List[float]]): Matriz de estado del sistema.
-    
+
     Returns:
         np.ndarray: Imagen en escala de grises (0-255).
     """
     try:
         imagen = np.array(matriz_estado, dtype=np.float32)
-        imagen = (imagen - np.min(imagen)) / (np.max(imagen) - np.min(imagen) + 1e-6) * 255
+        imagen = (
+            imagen - np.min(imagen)
+        ) / (np.max(imagen) - np.min(imagen) + 1e-6) * 255
         imagen = imagen.astype(np.uint8)
         logger.debug("Imagen capturada del estado.")
         return imagen
@@ -53,13 +57,14 @@ def capturar_imagen(matriz_estado: List[List[float]]) -> np.ndarray:
         logger.error(f"Error capturando imagen: {str(e)}")
         raise ValueError("Error al procesar la matriz de estado.")
 
+
 def procesar_imagen(imagen: np.ndarray) -> np.ndarray:
     """
     Aplica un reflejo horizontal a la imagen capturada.
-    
+
     Args:
         imagen (np.ndarray): Imagen en escala de grises.
-    
+
     Returns:
         np.ndarray: Imagen reflejada.
     """
@@ -71,13 +76,15 @@ def procesar_imagen(imagen: np.ndarray) -> np.ndarray:
         logger.error(f"Error procesando imagen: {str(e)}")
         raise ValueError("Error al aplicar transformación óptica.")
 
+
 def generar_retroalimentacion(imagen_procesada: np.ndarray) -> float:
     """
-    Genera una señal de retroalimentación normalizada a partir de la imagen procesada.
-    
+    Genera una señal de retroalimentacion normalizada a partir de la imagen
+    procesada.
+
     Args:
         imagen_procesada (np.ndarray): Imagen reflejada.
-    
+
     Returns:
         float: Señal de retroalimentación en el rango [0.0, 1.0].
     """
@@ -89,13 +96,14 @@ def generar_retroalimentacion(imagen_procesada: np.ndarray) -> float:
         logger.error(f"Error generando retroalimentación: {str(e)}")
         raise ValueError("Error al calcular la retroalimentación.")
 
+
 def retroalimentacion_optica(matriz_estado: List[List[float]]) -> float:
     """
     Integra la captura, procesamiento y generación de retroalimentación.
-    
+
     Args:
         matriz_estado (List[List[float]]): Matriz de estado del sistema.
-    
+
     Returns:
         float: Señal de retroalimentación óptica.
     """
@@ -107,25 +115,28 @@ def retroalimentacion_optica(matriz_estado: List[List[float]]) -> float:
         logger.error(f"Error en retroalimentación óptica: {str(e)}")
         raise
 
+
 @app.route("/api/optical-feedback", methods=["POST"])
 def obtener_retroalimentacion() -> jsonify:
     """
     Endpoint REST para obtener retroalimentación óptica.
-    
+
     Expects:
         JSON con clave 'estado' (matriz de estado).
-    
+
     Returns:
         jsonify: Respuesta JSON con retroalimentación o mensaje de error.
     """
     try:
         datos = request.get_json()
         if not datos or "estado" not in datos:
-            return jsonify({
-                "status": "error",
-                "message": "Debe enviarse un JSON con la clave 'estado'."
-            }), 400
-        
+            return jsonify(
+                {
+                    "status": "error",
+                    "message": "Debe enviarse un JSON con la clave 'estado'.",
+                }
+            ), 400
+
         matriz_estado = datos["estado"]
         retroalimentacion = retroalimentacion_optica(matriz_estado)
         return jsonify({
@@ -144,11 +155,12 @@ def obtener_retroalimentacion() -> jsonify:
             "message": "Error interno del servidor."
         }), 500
 
+
 @app.route("/api/health", methods=["GET"])
 def salud() -> jsonify:
     """
     Endpoint de salud para monitoreo del módulo.
-    
+
     Returns:
         jsonify: Respuesta JSON con estado del módulo.
     """
@@ -158,18 +170,21 @@ def salud() -> jsonify:
         "mensaje": "Módulo operativo"
     }), 200
 
+
 def iniciar_servicio(host: str = "0.0.0.0", port: int = 8001) -> None:
     """
     Inicia el servidor Flask para el controlador óptico.
-    
+
     Args:
         host (str): Dirección IP del host.
         port (int): Puerto de escucha.
     """
     logger.info(f"Iniciando servicio en {host}:{port}")
     app.run(host=host, port=port, debug=False)
-    
-# Alias para compatibilidad con pruebas y otros módulos que importen nombres en inglés
+
+
+# Alias para compatibilidad con pruebas y otros módulos que importen nombres
+# en inglés
 capture_image = capturar_imagen
 process_image = procesar_imagen
 generate_feedback = generar_retroalimentacion


### PR DESCRIPTION
This commit addresses all flake8 violations in the `optical_controller/optical_controller.py` file.

The following issues were fixed:
- E501: Line too long
- F401: Unused import (typing.Dict, typing.Any)
- E302: Expected 2 blank lines, found 1
- W293: Blank line contains whitespace
- E305: Expected 2 blank lines after class or function definition, found 1
- W292: No newline at end of file

These changes ensure the code adheres to PEP 8 standards and improves overall code quality and readability.