### PR TITLE
I've addressed some PEP 8 violations iin watchers_wave y focus

### DIFF
--- a/tests/unit/test_watcher_focus.py
+++ b/tests/unit/test_watcher_focus.py
@@ -6,28 +6,42 @@ test_watcher_focus.py
 import pytest
 import requests
 from unittest.mock import patch
+# Import current_state directly as it's used elsewhere and seems fine
 from watchers_modules.watcher_focus.watcher_focus import current_state
 import threading
 import time
 import os
+# Import only the top-level package
+import watchers_modules
 
 # Parametrizar la URL base para el módulo watcher_focus.
 FOCUS_URL = os.environ.get("WATCHER_FOCUS_URL", "http://localhost:6000")
 
+
 @pytest.fixture
 def watcher_focus_thread():
-    """Fixture para iniciar el hilo de simulación y detenerlo después de la prueba."""
-    from watchers_modules.watcher_focus.watcher_focus import simulate_watcher_focus_infinite
-    thread = threading.Thread(target=simulate_watcher_focus_infinite, args=(0.001,), daemon=True)
+    """Inicia y detiene el hilo de simulación para pruebas."""
+    # Access simulate_watcher_focus_infinite function
+    # from the watcher_focus module.
+    module_obj = watchers_modules.watcher_focus.watcher_focus
+    func_path = module_obj.simulate_watcher_focus_infinite
+    thread = threading.Thread(
+        target=func_path,
+        args=(0.001,),
+        daemon=True
+    )
     thread.start()
     time.sleep(0.01)  # Dar tiempo a que el estado se actualice
     yield
     # El hilo daemon se detendrá al finalizar el test
 
+
 def test_simulate_watcher_focus(watcher_focus_thread):
     """Verifica que el estado se actualice después de iniciar la simulación."""
     state = current_state
-    assert state["x"] is not None and state["y"] is not None, "El estado no se actualizó correctamente."
+    assert state["x"] is not None and \
+           state["y"] is not None, "El estado no se actualizó correctamente."
+
 
 @patch("requests.get")
 def test_get_focus_endpoint(mock_get):
@@ -35,8 +49,16 @@ def test_get_focus_endpoint(mock_get):
     mock_get.return_value.status_code = 200
     mock_get.return_value.json.return_value = {
         "status": "success",
-        "focus_state": {"t": 0.1, "x": 1.0, "y": 0.0, "z": 0.5, "phase": 0.0, "z_error": 0.5}
+        "focus_state": {
+            "t": 0.1,
+            "x": 1.0,
+            "y": 0.0,
+            "z": 0.5,
+            "phase": 0.0,
+            "z_error": 0.5
+        }
     }
     response = requests.get(FOCUS_URL + "/api/focus")
     mock_get.assert_called_once()
-    assert response.status_code == 200, "El endpoint /api/focus no respondió correctamente."
+    assert response.status_code == 200, \
+        "El endpoint /api/focus no respondió correctamente."

--- a/tests/unit/test_watchers_wave.py
+++ b/tests/unit/test_watchers_wave.py
@@ -14,9 +14,11 @@ MALLA_ENDPOINT = f"{BASE_URL}/api/malla"
 WAVE_CONTROL_ENDPOINT = f"{BASE_URL}/api/wave_control"
 ACOUSTIC_ENDPOINT = f"{BASE_URL}/api/acoustic"
 
+
 @pytest.fixture
 def watchers_wave_running():
     yield  # Se asume que el servicio está corriendo
+
 
 @patch('requests.get')
 def test_get_malla(mock_get, watchers_wave_running):
@@ -31,21 +33,32 @@ def test_get_malla(mock_get, watchers_wave_running):
     assert response.status_code == 200
     assert "malla_A" in response.json()
 
+
 @patch('requests.post')
 def test_wave_control(mock_post, watchers_wave_running):
     mock_post.return_value.status_code = 200
-    mock_post.return_value.json.return_value = {"status": "success", "c_current": 0.2}
-    response = requests.post(WAVE_CONTROL_ENDPOINT, json={"control_signal": 1.0})
+    mock_post.return_value.json.return_value = {
+        "status": "success",
+        "c_current": 0.2
+    }
+    post_data = {"control_signal": 1.0}
+    response = requests.post(WAVE_CONTROL_ENDPOINT, json=post_data)
     assert response.status_code == 200
     assert "c_current" in response.json()
+
 
 @patch('requests.get')
 def test_acoustic_get(mock_get, watchers_wave_running):
     mock_get.return_value.status_code = 200
-    mock_get.return_value.json.return_value = {"frecuencia": 20000, "amplitud": 0.5, "status": "success"}
+    mock_get.return_value.json.return_value = {
+        "frecuencia": 20000,
+        "amplitud": 0.5,
+        "status": "success"
+    }
     response = requests.get(ACOUSTIC_ENDPOINT)
     assert response.status_code == 200
     assert "frecuencia" in response.json()
+
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Specifically, I resolved E302, E305, and E501 errors in:
- tests/unit/test_watcher_focus.py
- tests/unit/test_watchers_wave.py

My modifications involved:
- Adding the appropriate blank lines before and after functions.
- Reformatting long lines to adhere to the 79-character limit.

The logical structure and behavior of the tests remain unchanged. I've also verified these changes with flake8 to ensure compliance.