### PR TITLE
Fix various linting errors and initial syntax error

### DIFF
--- a/control/boson_phase.py
+++ b/control/boson_phase.py
@@ -82,7 +82,9 @@ class BosonPhase:
             derivative = (error - self.last_error) / dt
         self.last_error = error
 
-        output = self.Kp * error + self.Ki * self.integral + self.Kd * derivative
+        output = (self.Kp * error +
+                  self.Ki * self.integral +
+                  self.Kd * derivative)
         logging.debug(
             f"upd -> err: {error:.3f}, "
             f"int: {self.integral:.3f}, "

--- a/tests/integration/test_integration_malla_ecu.py
+++ b/tests/integration/test_integration_malla_ecu.py
@@ -352,7 +352,8 @@ def test_malla_handles_ecu_field_vector_api_error(
             if "malla_watcher" in rec.name and rec.levelno >= logging.ERROR
         )
         assert log_message_found, (
-            "Malla Watcher no logueó error apropiado tras fallo API ECU."
+            "Malla Watcher no logueó error apropiado "
+            "tras fallo API ECU."
         )
 
 

--- a/tests/unit/test_malla_watcher.py
+++ b/tests/unit/test_malla_watcher.py
@@ -792,8 +792,8 @@ def mock_malla_map():
         patch(
             "watchers.watchers_tools.malla_watcher.malla_watcher"
             ".MAX_AMPLITUDE_FOR_NORMALIZATION", 20.0):
-        yield mock_mesh, mock_torus_capas, mock_torus_filas, \
-            mock_torus_columnas
+        yield (mock_mesh, mock_torus_capas, mock_torus_filas,
+               mock_torus_columnas)
 
 
 def test_map_cylinder_to_torus_coords(mock_malla_map):
@@ -822,7 +822,7 @@ def test_map_cylinder_to_torus_coords(mock_malla_map):
     # fila_idx = floor(z_norm * (NUM_FILAS - 1) + 0.5)
     # z_norm = (0.0 - (-10.0)) / (10.0 - (-10.0)) = 10.0 / 20.0 = 0.5
     # fila_idx = floor(0.5 * (10 - 1) + 0.5) = floor(0.5 * 9 + 0.5) = floor(4.5 + 0.5) = floor(5.0) = 5 -> clamped to 4
-    expected_coords = (2, 4, 7) # Original: (2, 4, 7)
+    expected_coords = (2, 4, 7)  # Original: (2, 4, 7)
     actual_coords = map_cylinder_to_torus_coords(cell)
     assert actual_coords == expected_coords
 
@@ -893,7 +893,8 @@ def test_api_health(client, reset_globals):
 
     with patch(
         "watchers.watchers_tools.malla_watcher.malla_watcher"
-        ".simulation_thread") as mock_sim_thread:
+        ".simulation_thread"
+    ) as mock_sim_thread:
         mock_sim_thread.is_alive.return_value = True
         response = client.get("/api/health")
         assert response.status_code == 200
@@ -1294,10 +1295,12 @@ def test_api_malla_influence_push(client, reset_globals):
 
     with patch(
         "watchers.watchers_tools.malla_watcher.malla_watcher"
-        ".apply_external_field_to_mesh") as mock_apply_func:
+        ".apply_external_field_to_mesh"
+    ) as mock_apply_func:
         response = client.post(
             "/api/malla/influence",
-            json={"field_vector": test_field_vector_payload})
+            json={"field_vector": test_field_vector_payload}
+        )
         assert response.status_code == 200
         data = response.get_json()
         assert data["status"] == "success"

--- a/tests/unit/test_matriz_ecu.py
+++ b/tests/unit/test_matriz_ecu.py
@@ -453,8 +453,12 @@ def test_endpoint_get_field_vector(cliente_flask):
     )
     # fmt: off
     campo_toroidal_global_servicio.aplicar_influencia(
-        NUM_CAPAS - 1, NUM_FILAS - 1, NUM_COLUMNAS - 1, influence_vector_3,
-        "test_vec_api_3")
+        NUM_CAPAS - 1,
+        NUM_FILAS - 1,
+        NUM_COLUMNAS - 1,
+        influence_vector_3,
+        "test_vec_api_3"
+    )
     # fmt: on
 
     response = cliente_flask.get("/api/ecu/field_vector")

--- a/tests/unit/test_solenoid_model.py
+++ b/tests/unit/test_solenoid_model.py
@@ -5,14 +5,21 @@ from agent_ai.model.solenoid_model import simulate_solenoid
 
 
 def test_simulate_field():
-    Intensidad = 0.5      # Corriente en amperios
+    I = 0.5      # Corriente en amperios
     n = 150      # Densidad de vueltas (vueltas por metro)
     R = 0.2      # Radio en metros (no usado en este modelo básico)
     t_end = 1.0  # Tiempo final de la simulación en segundos
     num_points = 100  # Número de puntos en la simulación
     mu0 = 4 * np.pi * 1e-7  # Permeabilidad del vacío
     # Se simula la evolución del campo magnético
-    t, sol = simulate_solenoid(I, n, R, initial_state=[0, 0], t_end=t_end, num_points=num_points)
+    t, sol = simulate_solenoid(
+        I,
+        n,
+        R,
+        initial_state=[0, 0],
+        t_end=t_end,
+        num_points=num_points
+    )
     # El componente Bz es el segundo elemento de cada estado, tomamos el final
     final_Bz = sol[-1, 1]
     expected_Bz = mu0 * n * I

--- a/watcher_security/exergy_model.py
+++ b/watcher_security/exergy_model.py
@@ -37,6 +37,7 @@ class ExergyModel:
     def optimize_energy_distribution(self, vector):
         """Maximiza exergía mediante optimización convexa"""
         from scipy.optimize import minimize
+
         def exergy_loss(x):
             return -np.dot(x, vector) + 0.5 * np.linalg.norm(x)**2
         constraints = {'type': 'ineq', 'fun': lambda x: np.sum(x) - 0.1}

--- a/watchers/watchers_tools/malla_watcher/malla_watcher.py
+++ b/watchers/watchers_tools/malla_watcher/malla_watcher.py
@@ -453,8 +453,11 @@ def update_aggregate_state():
     logger.debug(
         "Estado agregado actualizado: AvgAmp=%.3f, MaxAmp=%.3f, AvgVel=%.3f, "
         "MaxVel=%.3f, AvgKE=%.3f, MaxKE=%.3f, AvgActivity=%.3f, "
-        "MaxActivity=%.3f, OverThresh=%d", avg_amp, max_amp, avg_vel, max_vel,
-        avg_ke, max_ke, avg_activity, max_activity, over_thresh)
+        "MaxActivity=%.3f, OverThresh=%d",
+        avg_amp, max_amp, avg_vel, max_vel,
+        avg_ke, max_ke, avg_activity, max_activity,
+        over_thresh
+    )
 
 
 def calculate_flux(mesh: HexCylindricalMesh) -> float:
@@ -1153,10 +1156,12 @@ if __name__ == "__main__":
         MESH_CIRCUMFERENCE_SEGMENTS_REAL, MESH_HEX_SIZE_REAL,
         MESH_PERIODIC_Z_REAL)
     logger.info(
-        "Configuración Comms REAL: ECU_URL=%s, Torus=%dx%dx%d, InfThr=%.1f",
+        "Configuración Comms REAL: ECU_URL=%s, Torus=%dx%dx%d, "
+        "InfThr=%.1f",
         MATRIZ_ECU_BASE_URL_REAL, TORUS_NUM_CAPAS_REAL,
         TORUS_NUM_FILAS_REAL, TORUS_NUM_COLUMNAS_REAL,
-        AMPLITUDE_INFLUENCE_THRESHOLD_REAL)
+        AMPLITUDE_INFLUENCE_THRESHOLD_REAL
+    )
     logger.info(
         "Configuración Control REAL: BaseC=%.1f, BaseD=%.1f, GainC=%.1f, "
         "GainD=%.1f", BASE_COUPLING_T_REAL, BASE_DAMPING_E_REAL,

--- a/watchers/watchers_tools/malla_watcher/utils/cilindro_grafenal.py
+++ b/watchers/watchers_tools/malla_watcher/utils/cilindro_grafenal.py
@@ -111,7 +111,8 @@ class Cell:
         """
         return {
             "axial_coords": {"q": self.q_axial, "r": self.r_axial},
-            "cylindrical_coords": {"r": self.r, "theta": self.theta, "z": self.z},
+            "cylindrical_coords":
+                {"r": self.r, "theta": self.theta, "z": self.z},
             "amplitude": self.amplitude,
             "velocity": self.velocity,
             "q_vector": self.q_vector.tolist(),


### PR DESCRIPTION
Attempted to fix a range of linting errors reported by an initial log.

Steps taken:
1.  Fixed a SyntaxError in `tests/unit/test_malla_watcher.py` related to an incorrect line continuation in a `yield` statement. This required using `overwrite_file_with_block` due to issues with `replace_with_git_merge_diff`.
2.  Fixed F841 (unused variable) and F821 (undefined name) in `tests/unit/test_solenoid_model.py` by renaming 'Intensidad' to 'I'. This also required `overwrite_file_with_block` after issues with path interpretation (leading './').
3.  Addressed several E501 (line too long) errors across multiple files by reformatting lines.
4.  Fixed an E306 (missing blank line before nested function) in `watcher_security/exergy_model.py`.
5.  Installed `flake8` linter.
6.  Began addressing new linting errors reported by `flake8`:
    *   Fixed E127 (continuation line over-indented) in `control/boson_phase.py`.
    *   Attempted to fix some E129 (visually indented line with same indent as next logical line) in `tests/unit/test_malla_watcher.py`.
    *   Fixed one E261 (spacing before inline comment) in `tests/unit/test_malla_watcher.py`.

Further `flake8` runs revealed more errors and shifted line numbers, indicating an iterative approach is needed. The `replace_with_git_merge_diff` tool also showed inconsistent behavior initially.

This commit includes the fixes made up to the point of addressing the first E261 error. More linting errors remain as per the last `flake8` output.