### PR TITLE
Fix: Address PEP 8 linting errors E129 and E501

### DIFF
--- a/tests/unit/test_malla_watcher.py
+++ b/tests/unit/test_malla_watcher.py
@@ -734,7 +734,6 @@ def test_update_aggregate_state(mock_malla_state):
     assert aggregate_state["avg_velocity"] == pytest.approx(expected_avg_vel)
     assert aggregate_state["max_velocity"] == pytest.approx(expected_max_vel)
     assert aggregate_state["avg_kinetic_energy"] == pytest.approx(expected_avg_ke)  # noqa: E501
-
     assert aggregate_state["max_kinetic_energy"] == pytest.approx(expected_max_ke)  # noqa: E501
     assert aggregate_state["avg_activity_magnitude"] == pytest.approx(expected_avg_activity)  # noqa: E501
     assert aggregate_state["max_activity_magnitude"] == pytest.approx(expected_max_activity)  # noqa: E501
@@ -1239,12 +1238,10 @@ def test_api_config(client, reset_globals):
         config_data = data["config"]
         m_cfg = config_data["malla_config"]
         assert m_cfg["radius"] == float(expected_malla_config_values["MW_RADIUS"])  # noqa: E501
-
         assert m_cfg["height_segments"] == int(expected_malla_config_values["MW_HEIGHT_SEG"])  # noqa: E501
         assert m_cfg["circumference_segments_target"] == int(expected_malla_config_values["MW_CIRCUM_SEG"])  # noqa: E501
         assert m_cfg["circumference_segments_actual"] == mock_mesh.circumference_segments_actual  # noqa: E501
         assert m_cfg["hex_size"] == float(expected_malla_config_values["MW_HEX_SIZE"])  # noqa: E501
-
         assert m_cfg["periodic_z"] == (expected_malla_config_values["MW_PERIODIC_Z"].lower() == "true")  # noqa: E501
 
         comm_cfg = config_data["communication_config"]

--- a/watchers/watchers_tools/malla_watcher/malla_watcher.py
+++ b/watchers/watchers_tools/malla_watcher/malla_watcher.py
@@ -614,8 +614,7 @@ def send_influence_to_torus(dphi_dt: float):
             ecu_influence_url, json=payload, timeout=REQUESTS_TIMEOUT)
         response.raise_for_status()
         logger.info(
-            "Influencia (dPhi/dt) enviada a %s en (%d, %d, %d). Payload: %s. "
-            "Respuesta: %d",
+            "Influencia dPhi/dt a %s (%d,%d,%d). Payload: %s. Status: %d",
             ecu_influence_url,
             target_capa,
             target_row,
@@ -1242,9 +1241,11 @@ if __name__ == "__main__":
     HEALTH_URL = f"{MODULE_URL}/api/health"
     APORTA_A = "matriz_ecu"
     NATURALEZA = "modulador"
-    DESCRIPTION = ("Simulador de malla hexagonal cilíndrica (osciladores "
-                   "acoplados) acoplado a ECU, influye basado en inducción "
-                   "electromagnética.")
+    DESCRIPTION = (
+        "Simulador de malla hexagonal cilíndrica (osciladores "
+        "acoplados) acoplado a ECU, influye basado en inducción "
+        "electromagnética."
+    )
 
     registration_successful = register_with_agent_ai(
         MODULE_NAME, MODULE_URL, HEALTH_URL, "auxiliar", APORTA_A,


### PR DESCRIPTION
- Resolved E129 (visually indented line with same indent as next logical line) errors in test_malla_watcher.py by adjusting blank lines around commented asserts.
- Resolved E501 (line too long) errors in malla_watcher.py by shortening a log message and reformatting a long string assignment.