### PR TITLE
Add Spanish docstrings to harmony_controller.py

### DIFF
--- a/control/harmony_controller.py
+++ b/control/harmony_controller.py
@@ -1,14 +1,24 @@
-"""
-harmony_controller.py - Controlador Táctico del Ecosistema Watchers
+"""Controlador Táctico para el Ecosistema de Watchers (Harmony Controller).
 
-- Implementa el bucle de control principal (basado en PID).
-- Lee el estado de la matriz ECU.
-- Recibe notificaciones de AgentAI para tools auxiliares gestionados
-  (incluyendo naturaleza).
-- Recibe un setpoint (objetivo de armonía) de AgentAI.
-- Calcula señales de control para cada watcher_tool gestionado.
-- Envía las señales de control a los watchers_tools.
-- Expone su estado integrado y permite ajustar el setpoint vía API REST.
+Este módulo implementa el núcleo de control del sistema Harmony, diseñado para
+mantener un estado de equilibrio o "armonía" dentro de un ecosistema de
+componentes monitorizados denominados "watchers" y una entidad central de
+estado conocida como ECU (Estado de Campo Unificado).
+
+Funcionalidades Principales:
+    - Implementa un bucle de control principal basado en un controlador PID
+      (Proporcional-Integral-Derivativo) para ajustar dinámicamente el sistema.
+    - Interactúa con la Matriz ECU para obtener el estado actual del sistema.
+    - Recibe notificaciones y configuraciones desde una entidad de inteligencia
+      artificial (AgentAI), incluyendo el "setpoint" o estado objetivo de
+      armonía y el registro de nuevos "watcher tools".
+    - Calcula y distribuye señales de control optimizadas a cada watcher_tool
+      gestionado, basándose en la salida del PID y las características
+      específicas de cada tool.
+    - Proporciona una API RESTful para exponer su estado interno, recibir
+      actualizaciones del setpoint, y gestionar el registro de watcher_tools.
+    - Maneja la comunicación (obtención de estado y envío de controles) con los
+      watcher_tools y la ECU de manera robusta, incluyendo reintentos.
 """
 
 import time
@@ -63,7 +73,30 @@ BASE_RETRY_DELAY = float(os.environ.get("HC_BASE_RETRY_DELAY", 0.5))
 
 
 class HarmonyControllerState:
-    """Almacena el estado global del controlador Harmony."""
+    """Almacena y gestiona el estado global del Harmony Controller.
+
+    Esta clase encapsula todos los parámetros de configuración, el estado
+    operacional del controlador PID, la información sobre los watcher_tools
+    gestionados, y las últimas mediciones y salidas del sistema de control.
+    También incluye un cerrojo (Lock) para garantizar la concurrencia segura
+    al acceder o modificar su estado desde múltiples hilos.
+
+    Attributes:
+        pid_controller (BosonPhase): Instancia del controlador PID.
+        current_setpoint (float): El valor objetivo actual para el controlador PID.
+        setpoint_vector (List[float]): El vector de setpoint, que puede tener
+            múltiples dimensiones representando diferentes aspectos del objetivo.
+        last_ecu_state (List[List[float]]): El último estado recibido de la ECU.
+        managed_tools_details (Dict[str, Dict[str, Any]]): Un diccionario que
+            almacena los detalles de cada watcher_tool gestionado, incluyendo su
+            URL, a qué aspecto del control aporta, su naturaleza, y su último
+            estado conocido y señal de control enviada.
+        last_measurement (float): La última medición procesada del estado de la ECU
+            (normalmente la norma del vector de estado).
+        last_pid_output (float): La última salida calculada por el controlador PID.
+        lock (threading.Lock): Un cerrojo para proteger el acceso concurrente
+            a los atributos de la instancia.
+    """
 
     def __init__(
         self,
@@ -73,6 +106,20 @@ class HarmonyControllerState:
         initial_setpoint=setpoint_init,
         initial_setpoint_vector=setpoint_vector_init,
     ):
+        """Inicializa una nueva instancia de HarmonyControllerState.
+
+        Args:
+            kp (float, optional): Ganancia Proporcional inicial para el PID.
+                Por defecto es KP_INIT.
+            ki (float, optional): Ganancia Integral inicial para el PID.
+                Por defecto es KI_INIT.
+            kd (float, optional): Ganancia Derivativa inicial para el PID.
+                Por defecto es KD_INIT.
+            initial_setpoint (float, optional): Valor de setpoint inicial (norma).
+                Por defecto es setpoint_init.
+            initial_setpoint_vector (Union[np.ndarray, List[float]], optional):
+                Vector de setpoint inicial. Por defecto es setpoint_vector_init.
+        """
         self.pid_controller = BosonPhase(
             kp, ki, kd, setpoint=initial_setpoint
         )
@@ -92,7 +139,20 @@ class HarmonyControllerState:
         new_setpoint_value: float,
         new_setpoint_vector: Optional[List[float]] = None,
     ):
-        """Actualiza el setpoint del controlador PID."""
+        """Actualiza el setpoint del controlador PID y el vector de setpoint.
+
+        Este método modifica el valor objetivo (setpoint) que el controlador PID
+        intentará alcanzar. Opcionalmente, también puede actualizar el vector de
+        setpoint que puede usarse para una lógica de control más detallada.
+
+        Args:
+            new_setpoint_value (float): El nuevo valor de setpoint (norma) para el
+                controlador PID.
+            new_setpoint_vector (Optional[List[float]], optional): Una lista de
+                números que representa el nuevo vector de setpoint. Si es None,
+                el vector de setpoint no se modifica explícitamente por este
+                argumento, aunque el `current_setpoint` (norma) sí se actualiza.
+        """
         with self.lock:
             self.current_setpoint = new_setpoint_value
             self.pid_controller.setpoint = new_setpoint_value
@@ -106,7 +166,23 @@ class HarmonyControllerState:
     def register_managed_tool(
         self, nombre: str, url: str, aporta_a: str, naturaleza: str
     ):
-        """Registra o actualiza un watcher tool gestionado."""
+        """Registra un nuevo watcher_tool o actualiza uno existente.
+
+        Añade un watcher_tool al diccionario de tools gestionados por el
+        controlador. Si el tool ya existe (identificado por su nombre),
+        se actualiza su información.
+
+        Args:
+            nombre (str): El nombre identificador único del watcher_tool.
+            url (str): La URL base para comunicarse con la API del watcher_tool.
+            aporta_a (str): Un identificador que describe a qué aspecto o
+                componente del sistema contribuye o afecta este tool (ej.
+                "malla_watcher", "matriz_ecu"). Usado para mapear la señal de
+                control.
+            naturaleza (str): Describe la naturaleza del tool en relación con el
+                control (ej. "actuador", "sensor", "reductor", "convertidor").
+                Esto puede influir en cómo se aplica la señal de control.
+        """
         with self.lock:
             if nombre not in self.managed_tools_details:
                 self.managed_tools_details[nombre] = {}
@@ -127,7 +203,15 @@ class HarmonyControllerState:
             self.managed_tools_details[nombre]["last_control"] = 0.0
 
     def unregister_managed_tool(self, nombre: str):
-        """Elimina un watcher tool de la gestión."""
+        """Elimina un watcher_tool de la lista de tools gestionados.
+
+        Si el tool especificado por `nombre` se encuentra en la lista de
+        herramientas gestionadas, se elimina. Si no se encuentra, se registra
+        un mensaje de advertencia.
+
+        Args:
+            nombre (str): El nombre identificador único del watcher_tool a eliminar.
+        """
         with self.lock:
             if nombre in self.managed_tools_details:
                 logger.info("Eliminando tool gestionado: '%s'", nombre)
@@ -138,7 +222,20 @@ class HarmonyControllerState:
                 )
 
     def get_state_snapshot(self) -> Dict[str, Any]:
-        """Obtiene una instantánea del estado actual del controlador."""
+        """Obtiene una instantánea completa del estado actual del controlador.
+
+        Este método recopila todos los datos relevantes sobre el estado del
+        Harmony Controller, incluyendo el setpoint, la última medición, la
+        salida del PID, el estado de la ECU y los detalles de todos los
+        watcher_tools gestionados. Es seguro para ser llamado concurrentemente.
+
+        Returns:
+            Dict[str, Any]: Un diccionario que contiene una copia completa del
+            estado actual del controlador. Las claves incluyen:
+            'setpoint_value', 'setpoint_vector', 'last_measurement',
+            'last_pid_output', 'last_ecu_state', 'managed_tools' (con detalles
+            de cada tool), y 'pid_gains' (Kp, Ki, Kd).
+        """
         with self.lock:
             tools_snapshot = {
                 name: {
@@ -172,7 +269,22 @@ controller_state = HarmonyControllerState()
 
 
 def get_ecu_state() -> Optional[List[List[float]]]:
-    """Obtiene el estado unificado de la ECU vía API REST."""
+    """Obtiene el estado unificado del campo desde la Matriz ECU.
+
+    Realiza una solicitud GET a la API de la ECU para obtener su estado actual,
+    representado como una lista de listas de floats (matriz). Implementa una
+    lógica de reintentos en caso de fallo de comunicación.
+
+    La URL de la API de la ECU se obtiene de la variable de entorno ECU_API_URL.
+    El número máximo de reintentos y los tiempos de espera también son
+    configurables mediante variables de entorno.
+
+    Returns:
+        Optional[List[List[float]]]: Una lista de listas de floats que representa
+        el estado del campo unificado si la solicitud es exitosa y los datos son
+        válidos. Devuelve None si no se puede obtener el estado después de todos
+        los reintentos o si la respuesta no tiene el formato esperado.
+    """
     for attempt in range(MAX_RETRIES):
         try:
             response = requests.get(ECU_API_URL, timeout=REQUESTS_TIMEOUT)
@@ -210,7 +322,22 @@ def get_ecu_state() -> Optional[List[List[float]]]:
 
 
 def get_tool_state(tool_name: str, base_url: str) -> Dict[str, Any]:
-    """Obtiene el estado de un watcher_tool específico."""
+    """Obtiene el estado actual de un watcher_tool específico.
+
+    Realiza una solicitud GET al endpoint '/api/state' del watcher_tool indicado
+    por su `base_url`. Implementa una lógica de reintentos.
+
+    Args:
+        tool_name (str): El nombre del watcher_tool, usado para logging.
+        base_url (str): La URL base del API del watcher_tool.
+
+    Returns:
+        Dict[str, Any]: Un diccionario que representa el estado del tool.
+        Si la solicitud es exitosa, típicamente contiene una clave 'state'
+        con los datos específicos del tool. En caso de error después de
+        múltiples reintentos, devuelve un diccionario con un estado de 'error'
+        y un mensaje.
+    """
     state_url = f"{base_url}/api/state"
     for attempt in range(MAX_RETRIES):
         try:
@@ -244,8 +371,23 @@ def get_tool_state(tool_name: str, base_url: str) -> Dict[str, Any]:
     }
 
 
-def send_tool_control(tool_name: str, base_url: str, control_signal: float):
-    """Envía señal de control a un watcher_tool específico."""
+def send_tool_control(tool_name: str, base_url: str, control_signal: float) -> bool:
+    """Envía una señal de control a un watcher_tool específico.
+
+    Realiza una solicitud POST al endpoint '/api/control' del watcher_tool
+    indicado, enviando la `control_signal` en el cuerpo del JSON.
+    Implementa una lógica de reintentos.
+
+    Args:
+        tool_name (str): El nombre del watcher_tool, usado para logging.
+        base_url (str): La URL base del API del watcher_tool.
+        control_signal (float): El valor numérico de la señal de control a enviar.
+
+    Returns:
+        bool: True si la señal de control fue enviada y confirmada
+        exitosamente (HTTP 2xx). False si no se pudo enviar la señal después
+        de todos los reintentos.
+    """
     control_url = f"{base_url}/api/control"
     payload = {"control_signal": control_signal}
     for attempt in range(MAX_RETRIES):
@@ -275,7 +417,27 @@ def send_tool_control(tool_name: str, base_url: str, control_signal: float):
 
 
 def harmony_control_loop():
-    """Hilo de fondo que ejecuta el bucle de control táctico."""
+    """Ejecuta el bucle principal de control táctico del Harmony Controller.
+
+    Este es el corazón operativo del controlador. Se ejecuta en un hilo de fondo
+    dedicado y realiza las siguientes acciones en cada iteración:
+    1. Obtiene el estado actual de la ECU (Matriz de Estado Unificado).
+    2. Procesa el estado de la ECU para obtener una medición escalar (norma).
+    3. Calcula la salida del controlador PID basándose en el setpoint actual,
+       la medición y el tiempo transcurrido (dt).
+    4. Determina cómo distribuir la salida del PID entre los diferentes
+       watcher_tools gestionados. Esto se basa en un vector de setpoint
+       multidimensional y la afinidad de cada tool a los componentes de
+       este vector.
+    5. Envía las señales de control calculadas a cada watcher_tool.
+    6. Actualiza el estado interno del controlador (última medición, salida PID,
+       etc.).
+    7. Espera hasta el próximo intervalo de control.
+
+    El bucle se ejecuta indefinidamente hasta que el programa principal termina.
+    Toda la comunicación con los componentes externos (ECU, watcher_tools)
+    utiliza las funciones de utilidad que implementan reintentos.
+    """
     logger.info("Iniciando bucle de control Harmony...")
 
     affinity_to_setpoint_index = {"malla_watcher": 0, "matriz_ecu": 1}
@@ -407,7 +569,22 @@ app = Flask(__name__)
 
 @app.route("/api/health", methods=["GET"])
 def health_check():
-    """Endpoint para verificar la salud del servicio."""
+    """Verifica la salud del servicio Harmony Controller.
+
+    Este endpoint de API comprueba si el hilo principal del bucle de control
+    (`HarmonyControlLoop`) está activo.
+
+    Returns:
+        Response: Una respuesta JSON con el estado de salud.
+            Contiene las claves:
+            - `status` (str): "healthy" si el bucle de control está vivo,
+              "warning" en caso contrario.
+            - `service` (str): Siempre "harmony_controller".
+            - `control_loop_running` (bool): True si el hilo del bucle de
+              control está activo, False en caso contrario.
+            - `timestamp` (float): Timestamp actual.
+            El código de estado HTTP es 200.
+    """
     control_loop_alive = any(
         t.name == "HarmonyControlLoop" and t.is_alive()
         for t in threading.enumerate()
@@ -422,7 +599,19 @@ def health_check():
 
 @app.route("/api/harmony/state", methods=["GET"])
 def get_harmony_state():
-    """Devuelve el estado actual del controlador Harmony."""
+    """Obtiene el estado completo y actual del Harmony Controller.
+
+    Este endpoint de API devuelve una instantánea del estado del controlador,
+    incluyendo el setpoint actual, la última medición de la ECU, la última
+    salida del PID, detalles de los tools gestionados y las ganancias del PID.
+
+    Returns:
+        Response: Una respuesta JSON que contiene:
+            - `status` (str): "success".
+            - `data` (Dict[str, Any]): El objeto de estado obtenido de
+              `controller_state.get_state_snapshot()`.
+            El código de estado HTTP es 200.
+    """
     return jsonify({
         "status": "success",
         "data": controller_state.get_state_snapshot()
@@ -431,7 +620,29 @@ def get_harmony_state():
 
 @app.route("/api/harmony/setpoint", methods=["POST"])
 def set_harmony_setpoint():
-    """Permite actualizar el setpoint del controlador desde AgentAI."""
+    """Actualiza el setpoint del Harmony Controller.
+
+    Este endpoint de API permite a un cliente (como AgentAI) establecer un
+    nuevo vector de setpoint para el controlador. El controlador calculará
+    internamente la norma de este vector para usarla como setpoint escalar
+    para el PID.
+
+    El cuerpo de la solicitud debe ser un JSON con la clave "setpoint_vector",
+    que debe ser una lista de números (floats o ints).
+
+    Args:
+        request: El objeto de solicitud de Flask, se espera que contenga un
+                 payload JSON con `{"setpoint_vector": [v1, v2, ...]}`.
+
+    Returns:
+        Response: Una respuesta JSON indicando el resultado de la operación.
+            - Si es exitoso (HTTP 200): `{"status": "success", "message": "...",
+              "new_setpoint_value": <norma>, "new_setpoint_vector": <vector>}`.
+            - Si el payload es incorrecto (HTTP 400): `{"status": "error",
+              "message": "..."}`.
+            - Si hay un error de procesamiento (HTTP 400): `{"status": "error",
+              "message": "..."}`.
+    """
     data = request.get_json()
     if not data:
         return jsonify({
@@ -465,7 +676,33 @@ def set_harmony_setpoint():
 
 @app.route("/api/harmony/register_tool", methods=["POST"])
 def register_tool_from_ai():
-    """Endpoint para que AgentAI notifique sobre un tool gestionable."""
+    """Registra o actualiza un watcher_tool gestionado por el controlador.
+
+    Este endpoint es utilizado por AgentAI para informar al Harmony Controller
+    sobre un nuevo watcher_tool que debe ser gestionado, o para actualizar
+    los detalles de uno existente.
+
+    El cuerpo de la solicitud debe ser un JSON que contenga las claves:
+    `nombre` (str): Nombre identificador del tool.
+    `url` (str): URL base del API del tool.
+    `aporta_a` (str): A qué aspecto del sistema contribuye el tool.
+    `naturaleza` (str): Naturaleza del tool (ej. "actuador", "reductor").
+
+    Args:
+        request: El objeto de solicitud de Flask, se espera que contenga un
+                 payload JSON con los detalles del tool.
+
+    Returns:
+        Response: Una respuesta JSON indicando el resultado del registro.
+            - Si es exitoso (HTTP 200): `{"status": "success",
+              "message": "Tool '<nombre>' registrado/actualizado."}`.
+            - Si faltan datos en el payload (HTTP 400): `{"status": "error",
+              "message": "Faltan campos requeridos: ..."}`.
+            - Si el payload JSON está vacío (HTTP 400): `{"status": "error",
+              "message": "Payload JSON vacío o ausente."}`.
+            - Si ocurre un error interno (HTTP 500): `{"status": "error",
+              "message": "Error interno al registrar el tool."}`.
+    """
     data = request.get_json()
     if not data:
         logger.error("Solicitud a /register_tool sin payload JSON.")
@@ -502,7 +739,22 @@ def register_tool_from_ai():
 
 @app.route("/api/harmony/pid/reset", methods=["POST"])
 def reset_pid():
-    """Resetea los acumuladores del controlador PID."""
+    """Resetea el estado interno del controlador PID.
+
+    Este endpoint de API permite reiniciar los términos acumulados (como el
+    error integral) del controlador PID. Esto puede ser útil en situaciones
+    donde el controlador ha acumulado un error grande que impide una respuesta
+    adecuada a cambios recientes en el sistema.
+
+    Returns:
+        Response: Una respuesta JSON indicando el resultado de la operación.
+            - Si es exitoso (HTTP 200): `{"status": "success",
+              "message": "PID reiniciado."}`.
+            - Si el controlador PID no se encuentra (HTTP 500):
+              `{"status": "error", "message": "Controlador PID no encontrado."}`.
+            - Si ocurre un error interno (HTTP 500): `{"status": "error",
+              "message": "Error interno del servidor."}`.
+    """
     try:
         if hasattr(controller_state, "pid_controller"):
             controller_state.pid_controller.reset()
@@ -522,7 +774,17 @@ def reset_pid():
 
 
 def main():
-    """Función principal para iniciar el servicio."""
+    """Inicia el servicio Harmony Controller.
+
+    Esta función realiza dos acciones principales:
+    1. Crea e inicia un hilo demonio (`HarmonyControlLoop`) que ejecutará
+       el bucle de control principal del Harmony Controller en segundo plano.
+    2. Inicia el servidor Flask para exponer la API REST del controlador,
+       permitiendo la interacción externa para monitorización y control.
+
+    El host y puerto para el servidor Flask se configuran a través de variables
+    de entorno (`HC_PORT`, por defecto 7000) o valores predeterminados.
+    """
     control_thread = threading.Thread(
         target=harmony_control_loop, daemon=True, name="HarmonyControlLoop"
     )


### PR DESCRIPTION
Added comprehensive Spanish docstrings to the module, HarmonyControllerState class, all public methods, utility functions, Flask API endpoints, and the main function in control/harmony_controller.py.

Docstrings follow Google's format and PEP 257 best practices. No functional code was altered.