### PR TITLE
Refactor: Update imports to be absolute from project root

### DIFF
--- a/agent_ai/agent_ai.py
+++ b/agent_ai/agent_ai.py
@@ -35,8 +35,8 @@ import numpy as np
 import requests
 
 # Local application imports
-from .utils.logger import get_logger
-from .validation.validator import (
+from agent_ai.utils.logger import get_logger
+from agent_ai.validation.validator import (
     check_missing_dependencies,
     validate_module_registration,
 )

--- a/agent_ai/api/endpoints.py
+++ b/agent_ai/api/endpoints.py
@@ -9,8 +9,8 @@ módulos y recibir señales de control y configuración.
 """
 
 from flask import Flask, request, jsonify
-from utils.logger import get_logger
-from agent_ai import agent_ai_instance_app
+from agent_ai.utils.logger import get_logger
+from agent_ai.agent_ai import agent_ai_instance_app
 
 # import logging # No se usa directamente si usamos get_logger
 import os

--- a/control/harmony_controller.py
+++ b/control/harmony_controller.py
@@ -31,7 +31,7 @@ import json
 from flask import Flask, jsonify, request
 from typing import Dict, List, Any, Optional
 
-from .boson_phase import BosonPhase
+from control.boson_phase import BosonPhase
 
 ECU_API_URL = os.environ.get("ECU_API_URL", "http://ecu:8000/api/ecu")
 

--- a/tests/unit/test_unitarios.py
+++ b/tests/unit/test_unitarios.py
@@ -9,8 +9,9 @@ Suite de pruebas unitarias para los módulos:
 import pytest
 import math
 
-from .watchers_modules.watchers_wave.malla_watcher import Cell, PhosWave
-from .watchers_modules.watcher_focus.watcher_focus import update_indicators
+from watchers.watchers_tools.malla_watcher.utils.cilindro_grafenal import Cell
+from watchers.watchers_tools.malla_watcher.malla_watcher import PhosWave
+from watchers.watchers_tools.watcher_focus.watcher_focus import update_indicators
 
 
 ##############################

--- a/watchers/watchers_tools/malla_watcher/malla_watcher.py
+++ b/watchers/watchers_tools/malla_watcher/malla_watcher.py
@@ -46,7 +46,7 @@ import json
 from flask import Flask, request, jsonify
 import numpy as np
 from typing import List, Optional, Dict, Tuple, Any
-from .utils.cilindro_grafenal import HexCylindricalMesh, Cell
+from watchers.watchers_tools.malla_watcher.utils.cilindro_grafenal import HexCylindricalMesh, Cell
 
 # --- Configuración del Logging ---
 log_dir = "logs"

--- a/watchers/watchers_tools/solenoid_watcher/controller/solenoid_controller.py
+++ b/watchers/watchers_tools/solenoid_watcher/controller/solenoid_controller.py
@@ -6,7 +6,7 @@ Este módulo implementa un controlador PID para ajustar la señal de control
 del solenoide, utilizando el modelo físico implementado en solenoid_model.
 """
 
-from .agent_ai.model.solenoid_model import simulate_solenoid
+from watchers.watchers_tools.solenoid_watcher.model.solenoid_model import simulate_solenoid
 
 
 class SolenoidController:


### PR DESCRIPTION
Converted all relative imports within the project to be absolute, using the repository root as the base.

Corrected several instances where imports were structurally incorrect due to wrong assumptions about package locations (e.g., in `agent_ai.api.endpoints`, `watchers.watchers_tools.solenoid_watcher.controller.solenoid_controller`, and `tests.unit.test_unitarios`).

Testing was attempted but blocked by a persistent `ModuleNotFoundError` for the 'requests' package within `tests/conftest.py`, indicating an environment setup issue for the test runner.