### PR TITLE
Add Spanish docstrings and fix battery discharge logic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,16 +24,30 @@ def check_all_services_health(request):
     Fixture de sesión que verifica la salud de todos los servicios requeridos
     antes de que comience la ejecución de los tests de integración.
     Falla la sesión de test si algún servicio no está saludable.
+    Se ejecuta solo para tests dentro del directorio 'integration'.
     """
+    # Determinar si los tests que se están ejecutando son de integración
+    # Esto se puede hacer inspeccionando los items de la sesión o las rutas.
+    # Una forma simple es verificar si alguna ruta de test incluye "integration".
+    is_integration_run = False
+    for item in request.session.items:
+        if "integration" in item.nodeid.lower(): # O item.fspath si prefieres rutas de archivo
+            is_integration_run = True
+            break
+
+    if not is_integration_run:
+        logger.info("No es una ejecución de tests de integración. Saltando verificaciones de salud de servicios.")
+        return
+
     # Permitir saltar esta verificación si se pasa una opción a pytest
     if request.config.getoption("--skip-health-checks", default=False):
         logger.warning(
-            "Saltando verificaciones de salud de servicios pre-test."
+            "Saltando verificaciones de salud de servicios pre-test para tests de integración."
         )
         return
 
     logger.info(
-        "Iniciando verificación de salud de servicios pre-test..."
+        "Iniciando verificación de salud de servicios pre-test para tests de integración..."
     )
     all_healthy = True
     for service_name, base_url in SERVICES_TO_CHECK.items():


### PR DESCRIPTION
Summary of changes:

1.  **Added PEP257-compliant Spanish docstrings:**
    *   All public methods and the constructor of the `AtomicPiston` class in `atomic_piston/atomic_piston.py`.
    *   The test class, all test methods, and all fixtures in `tests/unit/test_atomic_piston.py`.

2.  **Implemented missing methods in `AtomicPiston`:**
    *   `set_mode(self, mode: PistonMode)`: Allows changing the piston's operational mode and resets battery discharge state.
    *   `trigger_discharge(self, discharge_on: bool)`: Allows enabling/disabling battery discharge only when in BATTERY mode.

3.  **Adjusted `conftest.py`:**
    *   Modified the `check_all_services_health` fixture to run health checks only for tests located under an 'integration' path. This prevents unit tests from being skipped unnecessarily.

4.  **Fixed logic in `AtomicPiston.discharge()` for BATTERY mode:**
    *   Ensured that `battery_is_discharging` is set to `False` if discharge is triggered but there is no current charge, or when the charge depletes to zero during discharge. This fixed the `test_discharge_battery_triggered_but_no_charge` test.
    *   Handled potential `NameError` for `UPDATE_INTERVAL` by providing a default `update_interval` of 0.01s within the `discharge` method if `UPDATE_INTERVAL` is not globally defined. Adjusted related test `test_discharge_battery_gradual_reduction` to align with this.

5.  **Attempted to fix `test_update_state_damping_effect`:**
    *   The test `test_update_state_damping_effect` is still failing. The assertion `velocities[-1] < initial_abs_velocity` fails because the spring force, under the test's initial conditions (high compression), overcomes the damping force, causing the velocity to initially increase rather than decrease.
    *   I identified this as a potential issue with the test's specific initial conditions and the relative strength of spring vs. damping, rather than a fundamental flaw in the damping logic itself. The test's docstring even mentions it's a "simplified check".

Remaining Issue:
*   The `test_update_state_damping_effect` in `tests/unit/test_atomic_piston.py` still fails. Further investigation is needed to either adjust the test parameters/assertions to better reflect expected damping behavior across various conditions or to refine the damping/spring interaction if a subtle issue exists. Given the current state, the primary request of adding docstrings and ensuring overall consistency has been largely met, with this one test being an outstanding point for refinement.