### PR TITLE
Fix: Correct indentation and syntax errors

### DIFF
--- a/atomic_piston/atomic_piston.py
+++ b/atomic_piston/atomic_piston.py
@@ -201,11 +201,11 @@ class AtomicPiston:
 
                 return {"type": "sustained", "amplitude": 1.0}
             else:  # current_charge is 0 or less
-                 self.battery_is_discharging = False
-                    logger.info(
-                        "Descarga BATTERY: No hay carga para liberar"
-                        "desactivando descarga."
-                    )
+                self.battery_is_discharging = False
+                logger.info(
+                    "Descarga BATTERY: No hay carga para liberar, "  # Added comma for clarity
+                    "desactivando descarga."
+                )
         
         return None
 

--- a/tests/unit/test_atomic_piston.py
+++ b/tests/unit/test_atomic_piston.py
@@ -217,7 +217,7 @@ class TestAtomicPiston:
         assert piston.last_applied_force == 0.0
 
     def test_update_state_spring_force_effect(
-        self
+        self,
         default_piston: AtomicPiston
     ):
         """Verifica el efecto de la fuerza del resorte en update_state."""


### PR DESCRIPTION
- Corrected an unexpected indent in atomic_piston/atomic_piston.py within the discharge method for battery mode.
- Fixed a syntax error (missing comma) in the method signature for test_update_state_spring_force_effect in tests/unit/test_atomic_piston.py.

These changes address linting/syntax errors identified in the build log.