### PR TITLE
Fix: PEP257 Completar docstrings en español para tests/unit/test_atom…

### DIFF
--- a/tests/unit/test_atomic_piston.py
+++ b/tests/unit/test_atomic_piston.py
@@ -312,8 +312,10 @@ class TestAtomicPiston:
         assert piston.velocity == pytest.approx(0.5)
 
     def test_update_state_damping_effect(self):
-        """
-        Verifica el efecto de la amortiguación en update_state comparando dos pistones.
+        """Verifica el efecto de la amortiguación en update_state.
+
+        Compara dos pistones con diferentes niveles de amortiguación,
+        asegurando que una mayor amortiguación resulte en una menor velocidad pico.
         """
         initial_position = -10.0
         time_steps = 300  # Simulate for enough steps to observe peak velocity
@@ -900,9 +902,11 @@ class TestAtomicPiston:
             self,
             default_piston: AtomicPiston
     ):
-        """
-        Verifica la estructura del output de generate_bode_data
-        y la longitud de los arrays.
+        """Verifica la estructura y longitud del output de generate_bode_data.
+
+        Asegura que el resultado sea un diccionario con las claves esperadas
+        ('frequencies', 'magnitude', 'phase') y que las longitudes de los arrays
+        coincidan con el rango de frecuencias de entrada.
         """
         piston = default_piston
         frequency_range = np.array([10, 100, 1000, 10000])  # Hz
@@ -947,9 +951,10 @@ class TestAtomicPiston:
             self,
             default_piston: AtomicPiston
     ):
-        """
-        Verifica el comportamiento de generate_bode_data
-        con un rango de frecuencias vacío.
+        """Verifica generate_bode_data con un rango de frecuencias vacío.
+
+        Asegura que el método maneje correctamente una entrada de frecuencia vacía,
+        produciendo un diccionario con claves correctas y arrays vacíos.
         """
         piston = default_piston
         frequency_range = np.array([])
@@ -1152,9 +1157,10 @@ class TestAtomicPiston:
             self,
             default_piston: AtomicPiston
     ):
-        """
-        Verifica el comportamiento de simulate_discharge_circuit
-        cuando no hay compresión.
+        """Verifica simulate_discharge_circuit sin compresión inicial.
+
+        Asegura que si el pistón no está comprimido (sin voltaje inicial),
+        no se disipe potencia y la posición del pistón no cambie.
         """
         piston = default_piston
         load_resistance = 10.0
@@ -1178,9 +1184,10 @@ class TestAtomicPiston:
             self,
             default_piston: AtomicPiston
     ):
-        """
-        Verifica que múltiples llamadas a simulate_discharge_circuit
-        continúan disipando energía.
+        """Verifica la disipación de energía con múltiples llamadas a simulate_discharge_circuit.
+
+        Asegura que llamadas sucesivas continúen disipando energía si hay voltaje
+        y que la posición del pistón se mueva progresivamente hacia cero.
         """
         piston = default_piston
         load_resistance = 5.0


### PR DESCRIPTION
…ic_piston.py

Se han revisado y completado las docstrings para los métodos de prueba en el archivo tests/unit/test_atomic_piston.py.

Las siguientes acciones se realizaron:
- Se mejoraron las docstrings existentes para mayor claridad y detalle.
- Se aseguró que todas las docstrings estén en español.
- Se verificó la conformidad con las convenciones de PEP 257, incluyendo el formato para líneas de resumen, uso de comillas triples, y correcta indentación.
- Se confirmó que la estructura general del archivo (ej. línea en blanco después de la docstring de la clase) sigue las recomendaciones.