### PR TITLE
fix: Correct invalid JavaScript in CSS

### DIFF
--- a/atomic_piston/IPU/pro_panel_ipu.html
+++ b/atomic_piston/IPU/pro_panel_ipu.html
@@ -399,7 +399,7 @@ body {
     }
 
     100% {
-        transform: translateY(-100px) translateX(${Math.random() > 0.5 ? 50 : -50}px) scale(0);
+        transform: translateY(-100px) translateX(50px) scale(0);
         opacity: 0;
     }
 }


### PR DESCRIPTION
This commit removes an invalid JavaScript expression from the `@keyframes float` animation in the `pro_panel_ipu.html` file. The expression was replaced with a valid CSS value to ensure the animation works correctly.