### PR TITLE
feat: Refactor container configuration for security and permissions

### DIFF
--- a/agent_ai/Dockerfile
+++ b/agent_ai/Dockerfile
@@ -1,28 +1,35 @@
-# 1. Imagen Base: Usa una imagen base de Python específica y slim.
-FROM python:3.12-slim-bookworm
+# Dockerfile para el servicio Agent AI
+FROM python:3.12-slim
 
-# 2. Entorno: Establece WORKDIR y variables de entorno.
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+# Establecer variables de entorno para Python
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
 WORKDIR /app
 
-# Instalar dependencias del sistema (curl para HEALTHCHECK y build-essential para compilación)
+# Instalar dependencias del sistema
 RUN apt-get update && apt-get install -y --no-install-recommends curl build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# 3. Optimización de Caché de Dependencias:
+# Crear un usuario y grupo no-root 'appuser' con UID/GID fijos
+RUN groupadd -r appgroup -g 1001 && \
+    useradd -r -u 1001 -g appgroup appuser
+
+# Copiar requirements.txt y instalar dependencias como root
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copia el resto del código de la aplicación.
+# Copiar el resto del código de la aplicación
 COPY . .
 
-# 4. Seguridad: Crea un usuario no-root y cambia a él.
-RUN useradd -m app
-USER app
+# Cambiar la propiedad de /app al usuario no-root
+RUN chown -R appuser:appgroup /app
 
-# 5. Metadatos y Ejecución:
+# Cambiar al usuario no-root para la ejecución
+USER appuser
+
+# Exponer el puerto específico de este servicio
 EXPOSE 9000
-HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -f http://localhost:9000/api/health || exit 1
 
+# Comando para ejecutar este servicio específico
 CMD ["python", "-m", "api.endpoints"]

--- a/control/Dockerfile
+++ b/control/Dockerfile
@@ -1,8 +1,10 @@
-# 1. Imagen Base: Usa una imagen base de Python específica y slim.
-FROM python:3.12-slim-bookworm
+# Dockerfile para el servicio Harmony Controller
+FROM python:3.12-slim
 
-# 2. Entorno: Establece WORKDIR y variables de entorno.
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+# Establecer variables de entorno para Python
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
 WORKDIR /app
 
 # Instalar dependencias del sistema
@@ -12,20 +14,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
     libglib2.0-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# 3. Optimización de Caché de Dependencias:
+# Crear un usuario y grupo no-root 'appuser' con UID/GID fijos
+RUN groupadd -r appgroup -g 1001 && \
+    useradd -r -u 1001 -g appgroup appuser
+
+# Copiar requirements.txt y instalar dependencias como root
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copia el resto del código de la aplicación.
+# Copiar el resto del código de la aplicación
 COPY . .
 
-# 4. Seguridad: Crea un usuario no-root y cambia a él.
-RUN useradd -m app
-USER app
+# Cambiar la propiedad de /app al usuario no-root
+RUN chown -R appuser:appgroup /app
 
-# 5. Metadatos y Ejecución:
+# Cambiar al usuario no-root para la ejecución
+USER appuser
+
+# Exponer el puerto específico de este servicio
 EXPOSE 7000
-HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -f http://localhost:7000/api/health || exit 1
 
+# Comando para ejecutar este servicio específico
 CMD ["python", "-m", "harmony_controller"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,6 +187,12 @@ services:
       - "${WATCHERS_WAVE_PORT}:5000"
     environment:
       - PORT=5000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/api/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   watcher_focus:
     <<: *common-config
@@ -198,6 +204,12 @@ services:
       - "${WATCHER_FOCUS_PORT}:6000"
     environment:
       - PORT=6000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6000/api/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
 # ==============================================================================
 # Top-level Resources

--- a/ecu/Dockerfile
+++ b/ecu/Dockerfile
@@ -1,36 +1,35 @@
-# 1. Imagen Base: Usa una imagen base de Python específica y slim.
-FROM python:3.12-slim-bookworm
+# Dockerfile para el servicio ECU
+FROM python:3.12-slim
 
-# 2. Entorno: Establece WORKDIR y variables de entorno.
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+# Establecer variables de entorno para Python
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
 WORKDIR /app
 
 # Instalar dependencias del sistema (curl para HEALTHCHECK)
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
-# 3. Optimización de Caché de Dependencias:
-# Copia solo el archivo de requerimientos para aprovechar la caché de Docker.
-COPY requirements.txt .
+# Crear un usuario y grupo no-root 'appuser' con UID/GID fijos
+RUN groupadd -r appgroup -g 1001 && \
+    useradd -r -u 1001 -g appgroup appuser
 
-# Instala las dependencias de Python.
+# Copiar requirements.txt y instalar dependencias como root
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copia el resto del código de la aplicación.
-# El .dockerignore debería usarse para excluir archivos innecesarios.
+# Copiar el resto del código de la aplicación
 COPY . .
 
-# 4. Seguridad: Crea un usuario no-root y cambia a él.
-RUN useradd -m app
-USER app
+# Cambiar la propiedad de /app al usuario no-root
+RUN chown -R appuser:appgroup /app
 
-# 5. Metadatos y Ejecución:
-# Expone el puerto que el servicio utiliza.
+# Cambiar al usuario no-root para la ejecución
+USER appuser
+
+# Exponer el puerto específico de este servicio
 EXPOSE 8000
 
-# Añade una instrucción HEALTHCHECK.
-HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -f http://localhost:8000/api/health || exit 1
-
-# Asegúrate de que la instrucción CMD final use el formato "exec".
+# Comando para ejecutar este servicio específico
 CMD ["python", "matriz_ecu.py"]

--- a/watchers/watchers_tools/malla_watcher/Dockerfile
+++ b/watchers/watchers_tools/malla_watcher/Dockerfile
@@ -1,28 +1,35 @@
-# 1. Imagen Base: Usa una imagen base de Python específica y slim.
-FROM python:3.12-slim-bookworm
+# Dockerfile para el servicio Malla Watcher
+FROM python:3.12-slim
 
-# 2. Entorno: Establece WORKDIR y variables de entorno.
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+# Establecer variables de entorno para Python
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
 WORKDIR /app
 
-# Instalar dependencias del sistema (curl para HEALTHCHECK)
+# Instalar dependencias del sistema
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
-# 3. Optimización de Caché de Dependencias:
+# Crear un usuario y grupo no-root 'appuser' con UID/GID fijos
+RUN groupadd -r appgroup -g 1001 && \
+    useradd -r -u 1001 -g appgroup appuser
+
+# Copiar requirements.txt y instalar dependencias como root
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copia el resto del código de la aplicación.
+# Copiar el resto del código de la aplicación
 COPY . .
 
-# 4. Seguridad: Crea un usuario no-root y cambia a él.
-RUN useradd -m app
-USER app
+# Cambiar la propiedad de /app al usuario no-root
+RUN chown -R appuser:appgroup /app
 
-# 5. Metadatos y Ejecución:
+# Cambiar al usuario no-root para la ejecución
+USER appuser
+
+# Exponer el puerto específico de este servicio
 EXPOSE 5001
-HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -f http://localhost:5001/api/health || exit 1
 
+# Comando para ejecutar este servicio específico
 CMD ["python", "malla_watcher.py"]

--- a/watchers/watchers_tools/watcher_focus/Dockerfile
+++ b/watchers/watchers_tools/watcher_focus/Dockerfile
@@ -1,28 +1,35 @@
-# 1. Imagen Base: Usa una imagen base de Python específica y slim.
-FROM python:3.12-slim-bookworm
+# Dockerfile para el servicio Watcher Focus
+FROM python:3.12-slim
 
-# 2. Entorno: Establece WORKDIR y variables de entorno.
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+# Establecer variables de entorno para Python
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
 WORKDIR /app
 
-# Instalar dependencias del sistema (curl para HEALTHCHECK)
+# Instalar dependencias del sistema
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
-# 3. Optimización de Caché de Dependencias:
+# Crear un usuario y grupo no-root 'appuser' con UID/GID fijos
+RUN groupadd -r appgroup -g 1001 && \
+    useradd -r -u 1001 -g appgroup appuser
+
+# Copiar requirements.txt y instalar dependencias como root
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copia el resto del código de la aplicación.
+# Copiar el resto del código de la aplicación
 COPY . .
 
-# 4. Seguridad: Crea un usuario no-root y cambia a él.
-RUN useradd -m app
-USER app
+# Cambiar la propiedad de /app al usuario no-root
+RUN chown -R appuser:appgroup /app
 
-# 5. Metadatos y Ejecución:
+# Cambiar al usuario no-root para la ejecución
+USER appuser
+
+# Exponer el puerto específico de este servicio
 EXPOSE 6000
-HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -f http://localhost:6000/api/health || exit 1
 
+# Comando para ejecutar este servicio específico
 CMD ["python", "watcher_focus.py"]

--- a/watchers/watchers_tools/watchers_wave/Dockerfile
+++ b/watchers/watchers_tools/watchers_wave/Dockerfile
@@ -1,28 +1,35 @@
-# 1. Imagen Base: Usa una imagen base de Python específica y slim.
-FROM python:3.12-slim-bookworm
+# Dockerfile para el servicio Watchers Wave
+FROM python:3.12-slim
 
-# 2. Entorno: Establece WORKDIR y variables de entorno.
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+# Establecer variables de entorno para Python
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
 WORKDIR /app
 
-# Instalar dependencias del sistema (curl para HEALTHCHECK)
+# Instalar dependencias del sistema
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
-# 3. Optimización de Caché de Dependencias:
+# Crear un usuario y grupo no-root 'appuser' con UID/GID fijos
+RUN groupadd -r appgroup -g 1001 && \
+    useradd -r -u 1001 -g appgroup appuser
+
+# Copiar requirements.txt y instalar dependencias como root
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copia el resto del código de la aplicación.
+# Copiar el resto del código de la aplicación
 COPY . .
 
-# 4. Seguridad: Crea un usuario no-root y cambia a él.
-RUN useradd -m app
-USER app
+# Cambiar la propiedad de /app al usuario no-root
+RUN chown -R appuser:appgroup /app
 
-# 5. Metadatos y Ejecución:
+# Cambiar al usuario no-root para la ejecución
+USER appuser
+
+# Exponer el puerto específico de este servicio
 EXPOSE 5000
-HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -f http://localhost:5000/api/health || exit 1
 
+# Comando para ejecutar este servicio específico
 CMD ["python", "watchers_wave.py"]


### PR DESCRIPTION
This commit refactors the container infrastructure to enhance security and resolve file permission errors when writing logs.

Key changes include:

- Standardizing all Python service Dockerfiles to use a non-root user ('appuser' with UID/GID 1001).
- Adding a 'chown' command to grant the 'appuser' ownership of the '/app' directory.
- Moving all healthcheck logic from Dockerfiles to the 'docker-compose.yml' file for centralized management.
- Verifying the shared log volume is correctly configured with the ':z' flag for SELinux compatibility.