### PR TITLE
I've refactored the logging in `matriz_ecu.py` and the configuration …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,12 +27,7 @@ x-common-config: &common-config
   restart: unless-stopped
   volumes:
     # Mount a shared volume to cache Pip packages, speeding up builds.
-    - pip-cache:/root/.cache/pip
-    # Mount a shared log directory for all services.
-    # The ':z' flag is crucial for Podman on SELinux-enabled systems (like Fedora, CentOS, RHEL).
-    # It tells the container runtime to relabel the host volume content, allowing the container
-    # to write to it without permission denied errors.
-    - ./logs:/app/logs:z
+    - pip-cache:/root/.cache/pip # El volumen de logs ha sido eliminado.
   networks:
     - watchers_net
   environment:

--- a/ecu/matriz_ecu.py
+++ b/ecu/matriz_ecu.py
@@ -24,6 +24,7 @@ Una simulación en segundo plano actualiza continuamente la dinámica del campo.
 
 import logging
 import os
+import sys
 import threading
 import time
 from typing import Any, Dict, List, Optional, Tuple
@@ -789,34 +790,19 @@ def main():
     global simulation_thread
 
     # --- Configuración del Logging ---
-    log_dir = "logs"
-    log_file = os.path.join(log_dir, "matriz_ecu.log")
-
-    # 1. Verificar si el directorio de logs existe y es escribible.
-    #    La creación del directorio es ahora una responsabilidad externa
-    #    (ej. docker-compose.yml o un script de arranque).
-    if not os.path.isdir(log_dir) or not os.access(log_dir, os.W_OK):
-        print(
-            f"FATAL: El directorio de logs '{log_dir}' no existe o no tiene "
-            "permisos de escritura. La aplicación no puede iniciar."
+    # Refactorizado para loguear siempre a stdout, siguiendo 12-Factor App.
+    # Se elimina la gestión de archivos de log y directorios.
+    if not logging.getLogger("matriz_ecu").hasHandlers():
+        logging.basicConfig(
+            level=logging.INFO,
+            format=(
+                "%(asctime)s [%(levelname)s] [%(threadName)s] "
+                "%(name)s: %(message)s"
+            ),
+            handlers=[
+                logging.StreamHandler(sys.stdout)  # Redirige los logs a la consola
+            ]
         )
-        exit(1)
-
-    # 2. Mover la configuración del logging dentro de main().
-    #    Usamos force=True (disponible en Python 3.8+) para asegurar que
-    #    esta configuración sobreescribe cualquier configuración por defecto.
-    logging.basicConfig(
-        level=logging.INFO,
-        format=(
-            "%(asctime)s [%(levelname)s] [%(threadName)s] "
-            "%(name)s: %(message)s"
-        ),
-        handlers=[
-            logging.FileHandler(log_file),
-            logging.StreamHandler()
-        ],
-        force=True
-    )
     # --- Fin Configuración del Logging ---
 
     logger.info(


### PR DESCRIPTION
…in `docker-compose.yml`. The new approach aligns with the "12-Factor App" methodology by logging to event streams (stdout).

This change addresses a persistent `PermissionError` you were encountering when writing logs to a host-mounted volume in a Podman environment.

Here are the changes I made:
- In `matriz_ecu.py`:
  - I removed the file-based logging (`FileHandler`).
  - I configured the logger to use `StreamHandler(sys.stdout)` to direct all log output to the standard output.
  - I removed the filesystem checks and directory creation logic.
- In `docker-compose.yml`:
  - I removed the `./logs:/app/logs:z` volume mount from the common configuration, as the application no longer writes to log files.

This approach simplifies the container configuration, eliminates dependencies on the host filesystem for logging, and permanently resolves the permission issue.