### PR TITLE
Refactor harmony_controller and agent_ai for module execution

### DIFF
--- a/agent_ai/Dockerfile
+++ b/agent_ai/Dockerfile
@@ -31,5 +31,9 @@ USER appuser
 # Exponer el puerto específico de este servicio
 EXPOSE 9000
 
-# Comando para ejecutar este servicio específico
-CMD ["python", "-m", "api.endpoints"]
+# Comando para ejecutar el servicio como un paquete de Python.
+# Esto establece 'agent_ai' como el paquete de nivel superior y ejecuta
+# el módulo 'endpoints' que se encuentra en el sub-paquete 'api'.
+# El WORKDIR es /app, y dentro de /app está el directorio agent_ai/,
+# por lo que Python puede encontrar el paquete agent_ai.
+CMD ["python", "-m", "agent_ai.api.endpoints"]

--- a/control/Dockerfile
+++ b/control/Dockerfile
@@ -34,5 +34,6 @@ USER appuser
 # Exponer el puerto específico de este servicio
 EXPOSE 7000
 
-# Comando para ejecutar este servicio específico
-CMD ["python", "harmony_controller.py"]
+# Comando para ejecutar el servicio como un paquete de Python.
+# Esto ejecuta el fichero __main__.py dentro del directorio/paquete 'control'.
+CMD ["python", "-m", "control"]

--- a/control/__main__.py
+++ b/control/__main__.py
@@ -1,0 +1,50 @@
+import os
+import threading
+import logging
+
+# Importar la app y el bucle de control desde el módulo principal
+from .harmony_controller import app, harmony_control_loop
+
+# Configurar un logger básico para este punto de entrada
+logger = logging.getLogger(__name__)
+
+def main():
+    """
+    Punto de entrada principal para ejecutar el servicio Harmony Controller.
+
+    Esta función realiza dos acciones clave:
+    1. Inicia el bucle de control principal (`harmony_control_loop`) en un
+       hilo de fondo. Este hilo se marca como 'daemon' para que no bloquee
+       la finalización del programa.
+    2. Inicia el servidor web Flask (`app.run`), que escucha las peticiones
+       HTTP en la dirección y puerto especificados.
+
+    La configuración del puerto se obtiene de la variable de entorno HC_PORT,
+    con un valor por defecto de 7000.
+    """
+    # Es buena práctica asegurarse de que el logging esté configurado.
+    # harmony_controller.py ya lo configura, pero si este script se ejecutara
+    # de alguna manera extraña, esto proporciona un fallback.
+    if not logging.getLogger().handlers:
+        logging.basicConfig(level=logging.INFO)
+
+    # 1. Iniciar el bucle de control en un hilo separado
+    control_thread = threading.Thread(
+        target=harmony_control_loop, daemon=True, name="HarmonyControlLoop"
+    )
+    control_thread.start()
+
+    # 2. Iniciar el servidor Flask
+    # El puerto se puede configurar a través de variables de entorno
+    port = int(os.environ.get("HC_PORT", 7000))
+    logger.info(
+        "Iniciando servidor Flask para Harmony Controller en el puerto %d...",
+        port
+    )
+    # use_reloader=False es importante para producción y para evitar
+    # que el código se ejecute dos veces.
+    # debug=False es igualmente crucial por seguridad y rendimiento.
+    app.run(host="0.0.0.0", port=port, debug=False, use_reloader=False)
+
+if __name__ == "__main__":
+    main()

--- a/control/harmony_controller.py
+++ b/control/harmony_controller.py
@@ -32,7 +32,7 @@ import uuid
 from flask import Flask, jsonify, request
 from typing import Dict, List, Any, Optional
 
-from .boson_phase import BosonPhase
+from .boson_phase import BosonPhasePID as BosonPhase
 
 ECU_API_URL = os.environ.get("ECU_API_URL", "http://ecu:8000/api/ecu")
 
@@ -129,8 +129,9 @@ class HarmonyControllerState:
                 Por defecto es setpoint_vector_init.
         """
         self.pid_controller = BosonPhase(
-            kp, ki, kd, setpoint=initial_setpoint
+            kp, ki, kd
         )
+        self.pid_controller.set_target(initial_setpoint)
         self.current_setpoint = initial_setpoint
         if isinstance(initial_setpoint_vector, np.ndarray):
             self.setpoint_vector = initial_setpoint_vector.tolist()
@@ -1147,29 +1148,5 @@ def abort_task_api(task_id: str):
     return jsonify({"status": "success", "message": "Señal de aborto enviada."}), 200
 
 
-def main():
-    """Inicia el servicio Harmony Controller.
-
-    Esta función realiza dos acciones principales:
-    1. Crea e inicia un hilo demonio (`HarmonyControlLoop`) que ejecutará
-       el bucle de control principal del Harmony Controller en segundo plano.
-    2. Inicia el servidor Flask para exponer la API REST del controlador,
-       permitiendo la interacción externa para monitorización y control.
-
-    El host y puerto para el servidor Flask se configuran a través de variables
-    de entorno (`HC_PORT`, por defecto 7000) o valores predeterminados.
-    """
-    control_thread = threading.Thread(
-        target=harmony_control_loop, daemon=True, name="HarmonyControlLoop"
-    )
-    control_thread.start()
-    port = int(os.environ.get("HC_PORT", 7000))
-    logger.info(
-        "Iniciando servidor Flask para Harmony Controller en puerto %d...",
-        port
-    )
-    app.run(host="0.0.0.0", port=port, debug=False, use_reloader=False)
-
-
-if __name__ == "__main__":
-    main()
+# El punto de entrada ha sido movido a __main__.py para permitir
+# la ejecución del módulo con `python -m control`.

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -11,72 +11,63 @@ from unittest.mock import patch, MagicMock
 
 # Importar la app Flask desde el módulo de endpoints refactorizado
 # Ajusta la ruta si tu estructura es diferente
-try:
-    from agent_ai.api.endpoints import app as agent_ai_app
-    # Importar la RUTA a la instancia para poder mockearla
-    AGENT_AI_INSTANCE_PATH = 'agent_ai.api.endpoints.agent_ai_instance_app'
-except ImportError:
-    # Fallback por si la estructura es plana
-    from endpoints import app as agent_ai_app
-    AGENT_AI_INSTANCE_PATH = 'agent_ai.api.endpoints.agent_ai_instance_app'
+from agent_ai.api.endpoints import app as agent_ai_app
+
+# La ruta a mockear es ahora el módulo 'agent_ai_core' que se importa
+# en 'endpoints.py'. Al mockear el módulo, podemos controlar su contenido,
+# incluyendo la instancia 'agent_ai_instance'.
+AGENT_AI_CORE_PATH = 'agent_ai.api.endpoints.agent_ai_core'
 
 
 @pytest.fixture
-def client_and_mock():  # Renombrar para claridad
+def client_and_mocks():
     """
-    Configura un cliente de prueba
-    Flask y la instancia mockeada de AgentAI.
+    Configura un cliente de prueba Flask y mockea el módulo `agent_ai_core`
+    entero, incluyendo su instancia y sus hilos.
+    Devuelve el cliente, el mock de la instancia y el mock del módulo.
     """
     agent_ai_app.config['TESTING'] = True
     agent_ai_app.config['WTF_CSRF_ENABLED'] = False
     with agent_ai_app.test_client() as client:
-        # Mockear la instancia global donde está definida
-        with patch(AGENT_AI_INSTANCE_PATH, autospec=True) as mock_instance:
-            # Configurar atributos necesarios para health check por defecto
-            # Esto evita errores si los tests no los configuran específicamente
-            mock_instance._strategic_thread = MagicMock(
-                spec=threading.Thread
-            )  # Crear un mock del hilo
-            mock_instance._strategic_thread.is_alive.return_value = True
-            # Por defecto, decir que está vivo
-
-            yield client, mock_instance
+        with patch(AGENT_AI_CORE_PATH) as mock_agent_ai_core:
+            mock_instance = MagicMock()
+            mock_agent_ai_core.agent_ai_instance = mock_instance
+            mock_agent_ai_core._strategic_thread = MagicMock(spec=threading.Thread)
+            mock_agent_ai_core.start_loop = MagicMock()
+            mock_agent_ai_core.shutdown = MagicMock()
+            yield client, mock_instance, mock_agent_ai_core
 
 
 # --- Tests para Endpoints ---
 
-def test_get_status_success(client_and_mock):
+def test_get_status_success(client_and_mocks):
     """Prueba GET /api/status exitoso."""
-    client, mock_instance = client_and_mock  # Desempaquetar
+    client, mock_instance, _ = client_and_mocks
 
     mock_data = {
         "target_setpoint_vector": [1.0],
         "current_strategy": "test",
         "registered_modules": []
     }
-    # Configurar el método del mock principal
     mock_instance.obtener_estado_completo.return_value = mock_data
 
     response = client.get("/api/status")
 
-    # Verificar la llamada en el mock principal
     mock_instance.obtener_estado_completo.assert_called_once()
     assert response.status_code == 200
     assert response.json['status'] == 'success'
     assert response.json['data'] == mock_data
 
 
-def test_post_strategic_command_success(client_and_mock):
+def test_post_strategic_command_success(client_and_mocks):
     """Prueba POST /api/command con un comando estratégico válido."""
-    client, mock_instance = client_and_mock
+    client, mock_instance, _ = client_and_mocks
     payload = {"comando": "set_strategy", "valor": "performance"}
     mock_response = {"status": "success", "mensaje": "Estrategia establecida"}
-    # Configurar el método del mock principal
     mock_instance.actualizar_comando_estrategico.return_value = mock_response
 
     response = client.post("/api/command", json=payload)
 
-    # Verificar la llamada en el mock principal
     mock_instance.actualizar_comando_estrategico.assert_called_once_with(
         "set_strategy", "performance"
     )
@@ -84,158 +75,119 @@ def test_post_strategic_command_success(client_and_mock):
     assert response.json == mock_response
 
 
-def test_post_strategic_command_fail(client_and_mock):
+def test_post_strategic_command_fail(client_and_mocks):
     """Prueba POST /api/command con comando estratégico que falla."""
-    client, mock_instance = client_and_mock
+    client, mock_instance, _ = client_and_mocks
     payload = {"comando": "unknown_command", "valor": None}
     mock_response = {"status": "error", "mensaje": "Comando no reconocido"}
-    # Configurar el método del mock principal
     mock_instance.actualizar_comando_estrategico.return_value = mock_response
 
     response = client.post("/api/command", json=payload)
 
-    # Verificar la llamada en el mock principal
     mock_instance.actualizar_comando_estrategico.assert_called_once_with(
         "unknown_command", None
     )
-    # El endpoint devuelve 400 si el comando falla
     assert response.status_code == 400
     assert response.json == mock_response
 
 
-def test_post_command_missing_field(client_and_mock):
+def test_post_command_missing_field(client_and_mocks):
     """Prueba POST /api/command sin el campo 'comando'."""
-    client, mock_instance = client_and_mock
-    # No necesitamos mockear aquí, la validación está en el endpoint
+    client, _, _ = client_and_mocks
     response = client.post("/api/command", json={"valor": "test"})
     assert response.status_code == 400
     assert "Falta el campo 'comando'" in response.json["mensaje"]
 
 
-def test_register_module_success(client_and_mock):
+def test_register_module_success(client_and_mocks):
     """Prueba POST /api/register exitoso."""
-    client, mock_instance = client_and_mock
+    client, mock_instance, _ = client_and_mocks
     module_data = {"nombre": "NewTool", "url": "http://newtool/health"}
     mock_response = {
         "status": "success",
         "mensaje": "Módulo 'NewTool' registrado"
     }
-    # Configurar el método del mock principal
     mock_instance.registrar_modulo.return_value = mock_response
 
     response = client.post("/api/register", json=module_data)
 
-    # Verificar la llamada en el mock principal
     mock_instance.registrar_modulo.assert_called_once_with(module_data)
     assert response.status_code == 200
     assert response.json == mock_response
-    # IMPORTANTE: Al mockear registrar_modulo, evitamos que se lance
-    # el hilo _validar_salud_modulo real
 
 
-def test_register_module_fail(client_and_mock):
-    """
-    Prueba POST /api/register con
-    fallo en la lógica interna.
-    """
-    client, mock_instance = client_and_mock
-    module_data = {"nombre": "BadTool", "url": ""}  # URL inválida
+def test_register_module_fail(client_and_mocks):
+    """Prueba POST /api/register con fallo en la lógica interna."""
+    client, mock_instance, _ = client_and_mocks
+    module_data = {"nombre": "BadTool", "url": ""}
     mock_response = {
         "status": "error",
         "mensaje": "Faltan campos obligatorios",
     }
-    # Configurar el método del mock principal
     mock_instance.registrar_modulo.return_value = mock_response
 
     response = client.post("/api/register", json=module_data)
 
-    # Verificar la llamada en el mock principal
     mock_instance.registrar_modulo.assert_called_once_with(module_data)
-    # Endpoint devuelve 400 si el registro falla
     assert response.status_code == 400
     assert response.json == mock_response
 
 
-def test_health_check_success(client_and_mock):
-    """
-    Prueba GET /api/health
-    cuando el bucle está activo.
-    """
-    client, mock_instance = client_and_mock
-    # Configurar el mock principal (ya debería tener _strategic_thread)
-    mock_instance._strategic_thread.is_alive.return_value = True
+def test_health_check_success(client_and_mocks):
+    """Prueba GET /api/health cuando el bucle está activo."""
+    client, _, mock_agent_ai_core = client_and_mocks
+    mock_agent_ai_core._strategic_thread.is_alive.return_value = True
 
     response = client.get("/api/health")
 
-    # Verificar que se consultó el atributo
-    mock_instance._strategic_thread.is_alive.assert_called_once()
+    mock_agent_ai_core._strategic_thread.is_alive.assert_called_once()
     assert response.status_code == 200
     data = response.json
     assert data["status"] == "success"
     assert data["strategic_loop_active"] is True
 
 
-def test_health_check_fail(client_and_mock):
-    """
-    Prueba GET /api/health
-    cuando el bucle NO está activo.
-    """
-    client, mock_instance = client_and_mock
-    # Configurar el mock principal
-    mock_instance._strategic_thread.is_alive.return_value = False
+def test_health_check_fail(client_and_mocks):
+    """Prueba GET /api/health cuando el bucle NO está activo."""
+    client, _, mock_agent_ai_core = client_and_mocks
+    mock_agent_ai_core._strategic_thread.is_alive.return_value = False
 
     response = client.get("/api/health")
 
-    # Verificar que se consultó el atributo
-    mock_instance._strategic_thread.is_alive.assert_called_once()
+    mock_agent_ai_core._strategic_thread.is_alive.assert_called_once()
     assert response.status_code == 503
     data = response.json
     assert data["status"] == "error"
     assert data["strategic_loop_active"] is False
 
 
-def test_control_input_success(client_and_mock):
-    """
-    Prueba POST /api/control
-    (entrada de cogniboard).
-    """
-    client, mock_instance = client_and_mock
+def test_control_input_success(client_and_mocks):
+    """Prueba POST /api/control (entrada de cogniboard)."""
+    client, mock_instance, _ = client_and_mocks
     payload = {"control_signal": 0.85}
-    # Configurar el método del mock principal
-    # (no necesita return_value si no devuelve nada)
 
     response = client.post("/api/control", json=payload)
 
-    # Verificar la llamada en el mock principal
     mock_instance.recibir_control_cogniboard.assert_called_once_with(0.85)
     assert response.status_code == 200
     assert response.json["status"] == "success"
 
 
-def test_control_input_missing_data(client_and_mock):
-    """
-    Prueba POST /api/control
-    sin 'control_signal'.
-    """
-    client, mock_instance = client_and_mock
+def test_control_input_missing_data(client_and_mocks):
+    """Prueba POST /api/control sin 'control_signal'."""
+    client, _, _ = client_and_mocks
     response = client.post("/api/control", json={})
     assert response.status_code == 400
     assert "Falta 'control_signal'" in response.json["mensaje"]
 
 
-def test_config_input_success(client_and_mock):
-    """
-    Prueba POST /api/config
-    (entrada de config_agent).
-    """
-    client, mock_instance = client_and_mock
+def test_config_input_success(client_and_mocks):
+    """Prueba POST /api/config (entrada de config_agent)."""
+    client, mock_instance, _ = client_and_mocks
     payload = {"config_status": {"docker": "ok", "network": "warning"}}
-    # Configurar el método del mock principal
-    # (no necesita return_value si no devuelve nada)
 
     response = client.post("/api/config", json=payload)
 
-    # Verificar la llamada en el mock principal
     mock_instance.recibir_config_status.assert_called_once_with(
         {"docker": "ok", "network": "warning"}
     )
@@ -243,12 +195,9 @@ def test_config_input_success(client_and_mock):
     assert response.json["status"] == "success"
 
 
-def test_config_input_missing_data(client_and_mock):
-    """
-    Prueba POST /api/config
-    sin 'config_status'.
-    """
-    client, mock_instance = client_and_mock
+def test_config_input_missing_data(client_and_mocks):
+    """Prueba POST /api/config sin 'config_status'."""
+    client, _, _ = client_and_mocks
     response = client.post("/api/config", json={})
     assert response.status_code == 400
     assert "Falta 'config_status'" in response.json["mensaje"]


### PR DESCRIPTION
This commit refactors the `harmony_controller` and `agent_ai` services to function as proper Python packages, resolving `ImportError` issues related to relative imports when running in Docker.

**harmony_controller:**
- A `control/__main__.py` entry point is created to house the Flask server startup logic.
- The startup logic is removed from `harmony_controller.py`.
- The Dockerfile is updated to use `CMD ["python", "-m", "control"]`, executing the service as a module.
- Corrected a `TypeError` during PID controller instantiation by using the `set_target` method instead of a `setpoint` kwarg in the constructor.

**agent_ai:**
- The service is refactored to have a single, clear entry point in `agent_ai/api/endpoints.py`.
- The `agent_ai.py` module is cleaned up to only contain the core `AgentAI` class and its logic, removing a duplicate Flask app.
- The Dockerfile is updated to use `CMD ["python", "-m", "agent_ai.api.endpoints"]`, which establishes the correct package context for relative imports.
- Unit tests for the `endpoints` API have been updated to reflect the new module structure and mocking strategy.