### PR TITLE
Fix(control): Corrige la llamada al método del controlador PID en har…

### DIFF
--- a/control/harmony_controller.py
+++ b/control/harmony_controller.py
@@ -756,8 +756,10 @@ def harmony_control_loop():
 
         pid_output = 0.0
         if hasattr(controller_state, "pid_controller"):
-            pid_output = controller_state.pid_controller.compute(
-                current_sp_norm, current_measurement, dt
+            # Corregido: Se llama al método `update` en lugar de `compute`
+            # y se pasan los argumentos correctos (`measurement`, `dt`).
+            pid_output = controller_state.pid_controller.update(
+                current_measurement, dt
             )
             logger.debug(
                 "[CtrlLoop] SP=%.3f, PV=%.3f, PIDOut=%.3f",


### PR DESCRIPTION
…mony_controller

Se ha reemplazado la llamada al método inexistente `.compute()` por la llamada al método correcto `.update()` en el objeto `BosonPhasePID`.

El error `AttributeError: 'BosonPhasePID' object has no attribute 'compute'` estaba causando que el bucle de control `HarmonyControlLoop` fallara.

La corrección implica:
- Cambiar `pid_controller.compute(...)` a `pid_controller.update(...)`.
- Ajustar los argumentos pasados al método para que coincidan con la firma de `update(measurement, dt)`, eliminando el argumento de `setpoint` que se gestiona internamente.