### PR TITLE
Fix config_agent findings in topology and Dockerfiles

### DIFF
--- a/agent_ai/Dockerfile
+++ b/agent_ai/Dockerfile
@@ -13,9 +13,8 @@ ENV PYTHONPATH "${PYTHONPATH}:/app"
 RUN apt-get update && apt-get install -y --no-install-recommends curl build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Crear un usuario y grupo no-root 'appuser' con UID/GID fijos
-RUN groupadd -r appgroup -g 1001 && \
-    useradd -r -u 1001 -g appgroup appuser
+# Crear un usuario y grupo no-root
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
 
 # Copiar el fichero de requisitos específico del servicio y instalar dependencias
 COPY agent_ai/requirements.txt ./
@@ -28,11 +27,11 @@ COPY common/ /app/common/
 # Cambiar la propiedad de /app al usuario no-root
 RUN chown -R appuser:appgroup /app
 
-# Cambiar al usuario no-root para la ejecución
-USER appuser
-
-# Exponer el puerto específico de este servicio
+# Exponer el puerto del servicio
 EXPOSE 9000
+
+# Cambiar al usuario no-root
+USER appuser
 
 # Comando para ejecutar el servicio como un paquete de Python.
 # Esto establece 'agent_ai' como el paquete de nivel superior y ejecuta

--- a/config/ecosystem_topology.yml
+++ b/config/ecosystem_topology.yml
@@ -29,6 +29,14 @@ services:
     type: auxiliar
     category: actuador # O 'convertidor', dependiendo de su función final
     description: "Unidad de Potencia Inteligente (IPU) para la gestión de energía pulsada."
+  watchers_wave:
+    type: auxiliar
+    category: modulador
+    description: "Herramienta auxiliar para modular ondas."
+  watcher_focus:
+    type: auxiliar
+    category: potenciador
+    description: "Herramienta auxiliar para potenciar el enfoque."
 
   # --- Servicios de Infraestructura ---
   agent_ai:
@@ -67,3 +75,8 @@ mic:
 
   config_agent:
     agent_ai: "SEND_CONFIG_REPORT"
+
+  ecu:
+    agent_ai: "REPORT_STATE"
+    harmony_controller: "READ_STATE"
+    malla_watcher: "READ_STATE"

--- a/control/Dockerfile
+++ b/control/Dockerfile
@@ -16,9 +16,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
     libglib2.0-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Crear un usuario y grupo no-root 'appuser' con UID/GID fijos
-RUN groupadd -r appgroup -g 1001 && \
-    useradd -r -u 1001 -g appgroup appuser
+# Crear un usuario y grupo no-root
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
 
 # Copiar el fichero de requisitos específico del servicio y instalar dependencias
 COPY control/requirements.txt ./
@@ -32,11 +31,11 @@ COPY common/ /app/common/
 # Cambiar la propiedad de /app al usuario no-root
 RUN chown -R appuser:appgroup /app
 
-# Cambiar al usuario no-root para la ejecución
-USER appuser
-
-# Exponer el puerto específico de este servicio
+# Exponer el puerto del servicio
 EXPOSE 7000
+
+# Cambiar al usuario no-root
+USER appuser
 
 # Comando para ejecutar el servicio como un paquete de Python.
 # Esto ejecuta el fichero __main__.py dentro del directorio/paquete 'control'.

--- a/ecu/Dockerfile
+++ b/ecu/Dockerfile
@@ -16,9 +16,8 @@ ENV PYTHONPATH "${PYTHONPATH}:/app"
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Crear un usuario y grupo no-root 'appuser' con UID/GID fijos
-RUN groupadd -r appgroup -g 1001 && \
-    useradd -r -u 1001 -g appgroup appuser
+# Crear un usuario y grupo no-root
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
 
 # Copiar el fichero de requisitos específico del servicio y instalar dependencias
 COPY ecu/requirements.txt ./
@@ -31,11 +30,11 @@ COPY common/ /app/common/
 # Cambiar la propiedad de /app al usuario no-root
 RUN chown -R appuser:appgroup /app
 
-# Cambiar al usuario no-root para la ejecución
-USER appuser
-
-# Exponer el puerto específico de este servicio
+# Exponer el puerto del servicio
 EXPOSE 8000
+
+# Cambiar al usuario no-root
+USER appuser
 
 # Ejecutar el servicio como un módulo dentro del paquete 'ecu'
 CMD ["python", "-m", "ecu.matriz_ecu"]

--- a/watchers/watchers_tools/malla_watcher/Dockerfile
+++ b/watchers/watchers_tools/malla_watcher/Dockerfile
@@ -16,9 +16,8 @@ ENV PYTHONPATH "${PYTHONPATH}:/app"
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Crear un usuario y grupo no-root 'appuser' con UID/GID fijos
-RUN groupadd -r appgroup -g 1001 && \
-    useradd -r -u 1001 -g appgroup appuser
+# Crear un usuario y grupo no-root
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
 
 # Copiar el fichero de requisitos específico del servicio y instalar dependencias
 COPY watchers/watchers_tools/malla_watcher/requirements.txt ./
@@ -32,11 +31,11 @@ COPY common/ /app/common/
 # Cambiar la propiedad de /app al usuario no-root
 RUN chown -R appuser:appgroup /app
 
-# Cambiar al usuario no-root para la ejecución
-USER appuser
-
-# Exponer el puerto específico de este servicio
+# Exponer el puerto del servicio
 EXPOSE 5001
+
+# Cambiar al usuario no-root
+USER appuser
 
 # Ejecutar el servicio como un módulo anidado dentro del paquete 'watchers'
 CMD ["python", "-m", "watchers.watchers_tools.malla_watcher.malla_watcher"]


### PR DESCRIPTION
- Adds watchers_wave and watcher_focus to ecosystem_topology.yml.
- Defines MIC permissions for the ecu service.
- Standardizes user creation in Dockerfiles for ecu, harmony_controller, agent_ai, and malla_watcher.
- Ensures USER and EXPOSE directives are present and correctly ordered in the Dockerfiles.