### PR TITLE
feat: Add API contract for matriz_ecu

### DIFF
--- a/api-contracts/matriz_ecu.v1.yml
+++ b/api-contracts/matriz_ecu.v1.yml
@@ -1,0 +1,99 @@
+openapi: 3.0.0
+info:
+  title: Matriz ECU API
+  description: API for the Matriz ECU microservice.
+  version: 1.0.0
+servers:
+  - url: http://matriz-ecu.watchers.local/
+    description: Local development server
+paths:
+  /api/health:
+    get:
+      summary: Health Check
+      description: Returns the health status of the service.
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+  /api/ecu/field_vector:
+    get:
+      summary: Get Field Vector
+      description: Retrieves the current field vector from the ECU.
+      responses:
+        '200':
+          description: The current field vector.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FieldVector'
+  /api/ecu/influence:
+    post:
+      summary: Post Influence
+      description: Sends an influence payload to the ECU.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InfluencePayload'
+      responses:
+        '202':
+          description: The influence was accepted.
+  /debug/set_random_phase:
+    post:
+      summary: Set Random Phase
+      description: Sets a random phase in the ECU for debugging purposes.
+      responses:
+        '200':
+          description: Random phase set successfully.
+
+components:
+  schemas:
+    FieldVector:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        vectors:
+          type: array
+          items:
+            type: array
+            items:
+              type: number
+              format: float
+      example:
+        timestamp: "2023-10-27T10:00:00Z"
+        vectors: [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+    InfluencePayload:
+      type: object
+      required:
+        - source
+        - type
+        - data
+      properties:
+        source:
+          type: string
+          description: The source of the influence.
+          example: "agent_ai"
+        type:
+          type: string
+          description: The type of influence.
+          example: "boson_collision"
+        data:
+          type: object
+          properties:
+            energy_level:
+              type: number
+              format: float
+              example: 98.6
+            particle_count:
+              type: integer
+              example: 1000


### PR DESCRIPTION
This commit introduces the initial API contract for the `matriz_ecu` service.

- Creates the `api-contracts` directory to store all the OpenAPI specifications.
- Adds the `matriz_ecu.v1.yml` file with the OpenAPI 3.0 specification for the `matriz_ecu` service.
- Defines the following endpoints:
  - GET /api/health
  - GET /api/ecu/field_vector
  - POST /api/ecu/influence
  - POST /debug/set_random_phase
- Defines the schemas for the request and response bodies.

This is the first step towards establishing an API-First culture in the "watchers" ecosystem.