### PR TITLE
Refactor: Clean up codebase using Ruff

### DIFF
--- a/agent_ai/api/endpoints.py
+++ b/agent_ai/api/endpoints.py
@@ -171,7 +171,10 @@ def synchronize_region_command():
             jsonify(
                 {
                     "status": "command_accepted",
-                    "message": f"Sincronización de fase iniciada para la región '{region}'.",
+                    "message": (
+                        "Sincronización de fase iniciada para la región "
+                        f"'{region}'."
+                    ),
                 }
             ),
             202,
@@ -179,7 +182,8 @@ def synchronize_region_command():
 
     except ValueError:
         logger.warning(
-            "Error de valor en /commands/synchronize_region: 'target_phase' no es un flotante válido. Payload: %s",
+            "Error de valor en /commands/synchronize_region: 'target_phase' "
+            "no es un flotante válido. Payload: %s",
             data,
         )
         return jsonify(

--- a/agent_ai/tests/unit/test_agent_ai.py
+++ b/agent_ai/tests/unit/test_agent_ai.py
@@ -95,10 +95,12 @@ class SleepCalled(Exception):
 def test_strategic_loop_pauses_when_architecture_is_not_validated(mocker):
     """
     Tests that the strategic loop pauses if the architecture is not validated.
+
     We mock time.sleep to raise an exception to break the loop for the test.
     """
     agent = AgentAI()
-    # By default, agent.is_architecture_validated is False, so the gate should be active.
+    # By default, agent.is_architecture_validated is False, so the gate
+    # should be active.
 
     mock_sleep = mocker.patch("time.sleep", side_effect=SleepCalled)
 

--- a/atomic_piston/config.py
+++ b/atomic_piston/config.py
@@ -23,7 +23,8 @@ class PistonConfig:
             self.friction_model = FrictionModel[friction_model_str]
         except KeyError:
             print(
-                f"Warning: Modelo de fricción '{friction_model_str}' inválido. Usando VISCOUS por defecto."
+                f"Warning: Modelo de fricción '{friction_model_str}' "
+                "inválido. Usando VISCOUS por defecto."
             )
             self.friction_model = FrictionModel.VISCOUS
 

--- a/atomic_piston/generate_schematic.py
+++ b/atomic_piston/generate_schematic.py
@@ -20,7 +20,7 @@ def create_schematic_netlist(filename="atomic_piston.net"):
     try:
         # (Pega aquí todo el contenido de tu función create_schematic_netlist)
         # ...
-        esp32 = Part(
+        Part(
             "Module", "ESP32-WROOM-32", footprint=FOOTPRINTS["ESP32"], dest="TEMPLATE"
         )
         # ... (resto de la definición de componentes y redes) ...

--- a/atomic_piston/pcb_atomic_piston_v2.py
+++ b/atomic_piston/pcb_atomic_piston_v2.py
@@ -11,7 +11,6 @@ from skidl import Net, Part, generate_schematic, reset
 try:
     import pcbnew
     from pcbnew import (
-        BOARD,
         EDGE_CUTS,
         EXCELLON_WRITER,
         PCB_SHAPE,

--- a/benzwatcher/api/endpoints.py
+++ b/benzwatcher/api/endpoints.py
@@ -37,7 +37,7 @@ def catalyze_signal(request: CatalysisRequest):
         return CatalysisResponse(adjusted_value=adjusted)
     except Exception as e:
         metrics.record_failure()
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 # Endpoint para exponer las métricas en formato compatible con Prometheus

--- a/cogniboard/monitor.py
+++ b/cogniboard/monitor.py
@@ -83,7 +83,7 @@ def calculate_entropy():
     Una entropía de 0 indica que todos los servicios están operativos.
     """
     failures = 0
-    for name, url in SERVICES.items():
+    for _name, url in SERVICES.items():
         if not fetch_health(url):
             failures += 1
     return float(failures)

--- a/config_agent/config_agent.py
+++ b/config_agent/config_agent.py
@@ -47,7 +47,10 @@ COMPOSE_PATH = "docker-compose.yml"
 
 
 def discover_interactions(service_data: Dict[str, Any]) -> List[str]:
-    """Parsea las variables de entorno de un servicio para encontrar URLs de otros servicios."""
+    """
+    Parsea las variables de entorno de un servicio para encontrar URLs de
+    otros servicios.
+    """
     interactions = []
     env_vars = service_data.get("environment", [])
     if not env_vars:
@@ -92,7 +95,9 @@ def build_report():
     for name, data in deployed_services.items():
         if name not in defined_services:
             logger.warning(
-                f"El servicio '{name}' se está desplegando pero no está definido en la topología."
+                "El servicio '%s' se está desplegando pero no está "
+                "definido en la topología.",
+                name,
             )
             continue
 
@@ -137,7 +142,8 @@ def send_report(report: Dict[str, Any], retries: int = 3, delay: int = 5):
             response = requests.post(AGENT_AI_CONFIG_ENDPOINT, json=report, timeout=15)
             response.raise_for_status()
             logger.info(
-                f"Informe de configuración enviado a agent_ai. Respuesta: {response.status_code}"
+                "Informe de configuración enviado a agent_ai. Respuesta: %s",
+                response.status_code,
             )
             return  # Envío exitoso, salimos de la función
         except requests.exceptions.RequestException as e:
@@ -149,7 +155,9 @@ def send_report(report: Dict[str, Any], retries: int = 3, delay: int = 5):
                 time.sleep(delay)
             else:
                 logger.error(
-                    f"No se pudo enviar el informe de configuración a agent_ai después de {retries} intentos."
+                    "No se pudo enviar el informe de configuración a agent_ai "
+                    "después de %s intentos.",
+                    retries,
                 )
                 break  # Salir del bucle después del último intento
 

--- a/control/harmony_controller.py
+++ b/control/harmony_controller.py
@@ -327,7 +327,8 @@ class TaskManager:
         with self.lock:
             if task_id in self.tasks:
                 self.tasks[task_id]["status"] = status
-                # Guardamos el estado final por si se consulta después de que el hilo muera
+                # Guardamos el estado final por si se consulta después de que
+                # el hilo muera
                 self.tasks[task_id]["final_status"] = status
                 logger.info(
                     "Estado de la tarea '%s' actualizado a: %s", task_id, status
@@ -522,7 +523,8 @@ def run_resonance_task(
 ):
     """Lógica de la tarea para la amplificación por resonancia."""
     logger.info(
-        "[%s] Iniciando tarea de resonancia en '%s' (Freq: %.2f Hz, Amp: %.2f, Dur: %.1fs)",
+        "[%s] Iniciando tarea de resonancia en '%s' (Freq: %.2f Hz, Amp: %.2f, "
+        "Dur: %.1fs)",
         task_id,
         region,
         frequency,
@@ -982,12 +984,18 @@ def set_harmony_setpoint():
                 }
             ), 200
         else:
-            return jsonify(
-                {
-                    "status": "error",
-                    "message": "Se requiere 'setpoint_vector' o 'setpoint_value' en JSON.",
-                }
-            ), 400
+            return (
+                jsonify(
+                    {
+                        "status": "error",
+                        "message": (
+                            "Se requiere 'setpoint_vector' o 'setpoint_value' "
+                            "en JSON."
+                        ),
+                    }
+                ),
+                400,
+            )
     except (ValueError, TypeError) as e:
         logger.error("Error al procesar nuevo setpoint: %s", e)
         return jsonify(

--- a/ecu/matriz_ecu.py
+++ b/ecu/matriz_ecu.py
@@ -508,7 +508,9 @@ def obtener_estado_unificado_api() -> Tuple[Any, int]:
             "status": "success",
             "estado_campo_unificado": campo_unificado.tolist(),
             "metadata": {
-                "descripcion": "Mapa de intensidad del campo toroidal ponderado por capa",
+                "descripcion": (
+                    "Mapa de intensidad del campo toroidal ponderado por capa"
+                ),
                 "capas": campo_toroidal_global_servicio.num_capas,
                 "filas": campo_toroidal_global_servicio.num_rows,
                 "columnas": campo_toroidal_global_servicio.num_cols,
@@ -650,7 +652,9 @@ def recibir_influencia_malla() -> Tuple[Any, int]:
             return jsonify(
                 {
                     "status": "success",
-                    "message": f"Influencia de '{parsed_data['nombre_watcher']}' aplicada.",
+                    "message": (
+                        f"Influencia de '{parsed_data['nombre_watcher']}' " "aplicada."
+                    ),
                     "applied_to": {
                         "capa": parsed_data["capa"],
                         "row": parsed_data["row"],
@@ -739,19 +743,27 @@ def set_random_phase_endpoint():
     # Comprobar si el entorno permite la ejecución de este endpoint
     if flask_env not in ["development", "test"]:
         logger.warning(
-            f"Acceso denegado a endpoint de depuración. Entorno actual: '{flask_env}'."
+            "Acceso denegado a endpoint de depuración. Entorno actual: '%s'.",
+            flask_env,
         )
-        return jsonify(
-            {
-                "status": "error",
-                "message": f"Endpoint de depuración no disponible en entorno '{flask_env}'.",
-            }
-        ), 403
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": (
+                        "Endpoint de depuración no disponible en entorno "
+                        f"'{flask_env}'."
+                    ),
+                }
+            ),
+            403,
+        )
 
     try:
         campo_toroidal_global_servicio.set_initial_quantum_phase()
         logger.info(
-            "Campo reiniciado a fase cuántica aleatoria a través de endpoint de depuración."
+            "Campo reiniciado a fase cuántica aleatoria a través de endpoint "
+            "de depuración."
         )
         return jsonify({"status": "success", "message": "Campo reiniciado"})
     except Exception as e:
@@ -767,12 +779,18 @@ def get_region_field_vector_api(capa_idx: int) -> Tuple[Any, int]:
     Endpoint REST para obtener el campo vectorial de una capa específica.
     """
     if not (0 <= capa_idx < campo_toroidal_global_servicio.num_capas):
-        return jsonify(
-            {
-                "status": "error",
-                "message": f"Índice de capa fuera de rango. Se esperaba entre 0 y {campo_toroidal_global_servicio.num_capas - 1}.",
-            }
-        ), 404
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": (
+                        "Índice de capa fuera de rango. Se esperaba entre 0 y "
+                        f"{campo_toroidal_global_servicio.num_capas - 1}."
+                    ),
+                }
+            ),
+            404,
+        )
 
     try:
         with campo_toroidal_global_servicio.lock:

--- a/generate_pcb.py
+++ b/generate_pcb.py
@@ -1,11 +1,11 @@
 import os
 import sys
 
+from atomic_piston.generate_schematic import create_schematic_netlist
+
 # Añadir la carpeta del proyecto al path para que las importaciones funcionen
 project_root = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(project_root)
-
-from atomic_piston.generate_schematic import create_schematic_netlist
 
 
 def main():
@@ -15,7 +15,6 @@ def main():
     # Definir rutas
     piston_dir = os.path.join(project_root, "atomic_piston")
     netlist_file = os.path.join(piston_dir, "atomic_piston.net")
-    pcb_file = os.path.join(piston_dir, "atomic_piston_layout.kicad_pcb")
 
     # --- PASO 1: Generar la netlist con SKiDL ---
     try:
@@ -41,13 +40,16 @@ def main():
     print("1. El archivo 'atomic_piston.net' ha sido creado.")
     print("2. Ahora, abre KiCad, crea un proyecto nuevo.")
     print(
-        "3. En el editor de esquemáticos, ve a Herramientas -> Importar -> Netlist y selecciona el archivo."
+        "3. En el editor de esquemáticos, ve a Herramientas -> Importar -> "
+        "Netlist y selecciona el archivo."
     )
     print(
-        "4. Luego, en el editor de esquemáticos, ve a Herramientas -> Actualizar PCB desde el Esquema."
+        "4. Luego, en el editor de esquemáticos, ve a Herramientas -> "
+        "Actualizar PCB desde el Esquema."
     )
     print(
-        "5. Finalmente, puedes ejecutar el script de refinamiento en la consola de KiCad."
+        "5. Finalmente, puedes ejecutar el script de refinamiento en la "
+        "consola de KiCad."
     )
 
 

--- a/optical_controller/optical_controller.py
+++ b/optical_controller/optical_controller.py
@@ -67,7 +67,7 @@ def capturar_imagen(matriz_estado: List[List[float]]) -> np.ndarray:
         return imagen
     except Exception as e:
         logger.error(f"Error capturando imagen: {str(e)}")
-        raise ValueError("Error al procesar la matriz de estado.")
+        raise ValueError("Error al procesar la matriz de estado.") from e
 
 
 def procesar_imagen(imagen: np.ndarray) -> np.ndarray:
@@ -94,7 +94,7 @@ def procesar_imagen(imagen: np.ndarray) -> np.ndarray:
         return imagen_reflejada
     except Exception as e:
         logger.error(f"Error procesando imagen: {str(e)}")
-        raise ValueError("Error al aplicar transformación óptica.")
+        raise ValueError("Error al aplicar transformación óptica.") from e
 
 
 def generar_retroalimentacion(imagen_procesada: np.ndarray) -> float:
@@ -123,7 +123,7 @@ def generar_retroalimentacion(imagen_procesada: np.ndarray) -> float:
         return retroalimentacion
     except Exception as e:
         logger.error(f"Error generando retroalimentación: {str(e)}")
-        raise ValueError("Error al calcular la retroalimentación.")
+        raise ValueError("Error al calcular la retroalimentación.") from e
 
 
 def retroalimentacion_optica(matriz_estado: List[List[float]]) -> float:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,4 @@
 [tool.ruff]
-# Enable Flake8 (E, F), isort (I), and Bugbear (B) rules
-select = ["E", "F", "I", "B"]
-ignore = []
-
 # Exclude common directories
 exclude = [
     ".bzr",
@@ -30,6 +26,10 @@ exclude = [
 # Line length
 line-length = 88
 target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B"]
+ignore = []
 
 [tool.ruff.format]
 # Black-compatible

--- a/tests/integration/test_atomic_piston_api.py
+++ b/tests/integration/test_atomic_piston_api.py
@@ -6,7 +6,8 @@ import threading
 
 import pytest
 
-# Se importa el módulo directamente para poder modificar sus variables globales en el entorno de prueba
+# Se importa el módulo directamente para poder modificar sus variables globales
+# en el entorno de prueba
 from atomic_piston import atomic_piston_service
 from atomic_piston.atomic_piston_service import AtomicPiston
 from atomic_piston.atomic_piston_service import app as agent_api
@@ -38,7 +39,8 @@ def reset_ipu_instance():
     # Se inicializa el objeto de configuración que el servicio espera
     atomic_piston_service.config = PistonConfig()
 
-    # Se modifica la instancia directamente en el módulo del servicio para que los endpoints la vean.
+    # Se modifica la instancia directamente en el módulo del servicio para que
+    # los endpoints la vean.
     atomic_piston_service.ipu_instance = AtomicPiston(
         capacity=10.0,
         elasticity=100.0,
@@ -47,8 +49,9 @@ def reset_ipu_instance():
         # Usar el modelo de fricción de la configuración por defecto para consistencia
         friction_model=atomic_piston_service.config.friction_model,
     )
-    # Se usa un mock de hilo no vivo para que `is_alive()` devuelva False, haciendo que
-    # el detalle 'simulation_running' en /api/health sea un booleano False en lugar de None.
+    # Se usa un mock de hilo no vivo para que `is_alive()` devuelva False,
+    # haciendo que el detalle 'simulation_running' en /api/health sea un
+    # booleano False en lugar de None.
     atomic_piston_service.simulation_thread = threading.Thread()
 
 
@@ -80,7 +83,8 @@ class TestStateEndpoint:
 
     def test_get_state_success(self, client):
         """
-        Verifica que se puede obtener el estado del pistón y que tiene la estructura correcta.
+        Verifica que se puede obtener el estado del pistón y que tiene la
+        estructura correcta.
         """
         # WHEN
         response = client.get("/api/state")

--- a/tests/integration/test_e2e_full_quantum_loop.py
+++ b/tests/integration/test_e2e_full_quantum_loop.py
@@ -87,8 +87,9 @@ def test_full_phase_synchronization_loop():
     """
     # --- Fase 1: Setup (Arrange) ---
     print("\n--- Phase 1: ARRANGE ---")
-    # Asegurar que el entorno de prueba esté configurado para permitir endpoints de depuración
-    # (esto se hace fuera del test, p.ej., con variables de entorno como FLASK_ENV=test)
+    # Asegurar que el entorno de prueba esté configurado para permitir
+    # endpoints de depuración (esto se hace fuera del test, p.ej., con
+    # variables de entorno como FLASK_ENV=test)
     set_ecu_to_random_phase(ECU_URL)
 
     # Darle un momento a la ECU para que se asiente si es necesario
@@ -97,7 +98,8 @@ def test_full_phase_synchronization_loop():
     initial_coherence = get_coherence_from_ecu(ECU_URL, TEST_REGION)
     print(f"Initial coherence: {initial_coherence:.4f}")
     assert initial_coherence < INITIAL_COHERENCE_THRESHOLD, (
-        f"Initial coherence {initial_coherence} was not below the threshold {INITIAL_COHERENCE_THRESHOLD}"
+        f"Initial coherence {initial_coherence} was not below the threshold "
+        f"{INITIAL_COHERENCE_THRESHOLD}"
     )
 
     # --- Fase 2: Acción (Act) ---
@@ -122,12 +124,14 @@ def test_full_phase_synchronization_loop():
         # Opcional: verificar si la coherencia está mejorando
         if current_coherence > last_coherence:
             print(
-                f"Progress: Coherence increased from {last_coherence:.4f} to {current_coherence:.4f}"
+                f"Progress: Coherence increased from {last_coherence:.4f} to "
+                f"{current_coherence:.4f}"
             )
         last_coherence = current_coherence
 
         time.sleep(POLLING_INTERVAL_SECONDS)
-    else:  # This 'else' belongs to the 'while' loop, it executes if the loop finishes without a 'break'
+    else:  # This 'else' belongs to the 'while' loop, it executes if the loop
+        # finishes without a 'break'
         pytest.fail(
             f"Test timed out after {POLLING_TIMEOUT_SECONDS} seconds. "
             f"Last measured coherence was {last_coherence:.4f}, "
@@ -138,5 +142,6 @@ def test_full_phase_synchronization_loop():
     print("\n--- Phase 4: ASSERT ---")
     print(f"Final coherence: {final_coherence:.4f}")
     assert final_coherence > FINAL_COHERENCE_THRESHOLD, (
-        f"Final coherence {final_coherence} did not meet the success threshold {FINAL_COHERENCE_THRESHOLD}"
+        f"Final coherence {final_coherence} did not meet the success threshold "
+        f"{FINAL_COHERENCE_THRESHOLD}"
     )

--- a/tests/unit/test_agent_ai.py
+++ b/tests/unit/test_agent_ai.py
@@ -438,10 +438,12 @@ class TestAgentAI(unittest.TestCase):
             la magnitud del setpoint se reduce.
 
         Args:
-            mock_logger, Mock para el logger.
-            mock_validate_module_registration, Mock de la función de validación de registro.
-            mock_check_missing_dependencies, Mock de la función de chequeo de dependencias.
-            mock_requests, Mock del módulo `requests`.
+            mock_logger: Mock para el logger.
+            mock_validate_module_registration: Mock de la función de
+                validación de registro.
+            mock_check_missing_dependencies: Mock de la función de chequeo de
+                dependencias.
+            mock_requests: Mock del módulo `requests`.
         """
 
         # Caso default: sin cambios
@@ -610,10 +612,12 @@ class TestAgentAI(unittest.TestCase):
         debe ser igual al setpoint objetivo actual del agente.
 
         Args:
-            mock_logger, Mock para el logger.
-            mock_validate_module_registration, Mock de la función de validación de registro.
-            mock_check_missing_dependencies, Mock de la función de chequeo de dependencias.
-            mock_requests, Mock para el módulo `requests`.
+            mock_logger: Mock para el logger.
+            mock_validate_module_registration: Mock de la función de
+                validación de registro.
+            mock_check_missing_dependencies: Mock de la función de chequeo de
+                dependencias.
+            mock_requests: Mock para el módulo `requests`.
         """
         initial_vector = [1.5, -0.5]
         self.agent.target_setpoint_vector = list(initial_vector)
@@ -653,10 +657,12 @@ class TestAgentAI(unittest.TestCase):
         reduzca en un factor predeterminado (0.98).
 
         Args:
-            mock_logger, Mock para el logger.
-            mock_validate_module_registration, Mock de la función de validación de registro.
-            mock_check_missing_dependencies, Mock de la función de chequeo de dependencias.
-            mock_requests, Mock para el módulo `requests`.
+            mock_logger: Mock para el logger.
+            mock_validate_module_registration: Mock de la función de
+                validación de registro.
+            mock_check_missing_dependencies: Mock de la función de chequeo de
+                dependencias.
+            mock_requests: Mock para el módulo `requests`.
         """
         initial_vector = [2.0, 0.0]
         initial_norm = np.linalg.norm(initial_vector)
@@ -697,10 +703,12 @@ class TestAgentAI(unittest.TestCase):
         un factor predeterminado (0.98), independientemente del error actual.
 
         Args:
-            mock_logger, Mock para el logger.
-            mock_validate_module_registration, Mock de la función de validación de registro.
-            mock_check_missing_dependencies, Mock de la función de chequeo de dependencias.
-            mock_requests, Mock para el módulo `requests`.
+            mock_logger: Mock para el logger.
+            mock_validate_module_registration: Mock de la función de
+                validación de registro.
+            mock_check_missing_dependencies: Mock de la función de chequeo de
+                dependencias.
+            mock_requests: Mock para el módulo `requests`.
         """
         initial_vector = [2.0, 0.0]
         initial_norm = np.linalg.norm(initial_vector)
@@ -743,10 +751,12 @@ class TestAgentAI(unittest.TestCase):
         (factor 0.97 sobre la reducción anterior).
 
         Args:
-            mock_logger, Mock para el logger.
-            mock_validate_module_registration, Mock de la función de validación de registro.
-            mock_check_missing_dependencies, Mock de la función de chequeo de dependencias.
-            mock_requests, Mock para el módulo `requests`.
+            mock_logger: Mock para el logger.
+            mock_validate_module_registration: Mock de la función de
+                validación de registro.
+            mock_check_missing_dependencies: Mock de la función de chequeo de
+                dependencias.
+            mock_requests: Mock para el módulo `requests`.
         """
         initial_vector = [2.0, 0.0]
         initial_norm = np.linalg.norm(initial_vector)
@@ -807,10 +817,12 @@ class TestAgentAI(unittest.TestCase):
         en un factor predeterminado (1.02).
 
         Args:
-            mock_logger, Mock para el logger.
-            mock_validate_module_registration, Mock de la función de validación de registro.
-            mock_check_missing_dependencies, Mock de la función de chequeo de dependencias.
-            mock_requests, Mock para el módulo `requests`.
+            mock_logger: Mock para el logger.
+            mock_validate_module_registration: Mock de la función de
+                validación de registro.
+            mock_check_missing_dependencies: Mock de la función de chequeo de
+                dependencias.
+            mock_requests: Mock para el módulo `requests`.
         """
         initial_vector = [2.0, 0.0]
         initial_norm = np.linalg.norm(initial_vector)
@@ -851,10 +863,12 @@ class TestAgentAI(unittest.TestCase):
         (factor 1.01 sobre el aumento anterior).
 
         Args:
-            mock_logger, Mock para el logger.
-            mock_validate_module_registration, Mock de la función de validación de registro.
-            mock_check_missing_dependencies, Mock de la función de chequeo de dependencias.
-            mock_requests, Mock para el módulo `requests`.
+            mock_logger: Mock para el logger.
+            mock_validate_module_registration: Mock de la función de
+                validación de registro.
+            mock_check_missing_dependencies: Mock de la función de chequeo de
+                dependencias.
+            mock_requests: Mock para el módulo `requests`.
         """
         initial_vector = [2.0, 0.0]
         initial_norm = np.linalg.norm(initial_vector)
@@ -916,10 +930,12 @@ class TestAgentAI(unittest.TestCase):
         (ej. [0.1, 0.1] para un vector 2D) para iniciar la actividad.
 
         Args:
-            mock_logger, Mock para el logger.
-            mock_validate_module_registration, Mock de la función de validación de registro.
-            mock_check_missing_dependencies, Mock de la función de chequeo de dependencias.
-            mock_requests, Mock para el módulo `requests`.
+            mock_logger: Mock para el logger.
+            mock_validate_module_registration: Mock de la función de
+                validación de registro.
+            mock_check_missing_dependencies: Mock de la función de chequeo de
+                dependencias.
+            mock_requests: Mock para el módulo `requests`.
         """
         initial_vector = [0.0, 0.0]  # Setpoint inicial cero
         initial_norm = 0.0
@@ -958,10 +974,12 @@ class TestAgentAI(unittest.TestCase):
         debe reducirse en un factor predeterminado (0.95).
 
         Args:
-            mock_logger, Mock para el logger.
-            mock_validate_module_registration, Mock de la función de validación de registro.
-            mock_check_missing_dependencies, Mock de la función de chequeo de dependencias.
-            mock_requests, Mock para el módulo `requests`.
+            mock_logger: Mock para el logger.
+            mock_validate_module_registration: Mock de la función de
+                validación de registro.
+            mock_check_missing_dependencies: Mock de la función de chequeo de
+                dependencias.
+            mock_requests: Mock para el módulo `requests`.
         """
         initial_vector = [2.0, 0.0]
         initial_norm = np.linalg.norm(initial_vector)
@@ -1008,10 +1026,12 @@ class TestAgentAI(unittest.TestCase):
         cambiar respecto al setpoint objetivo actual del agente.
 
         Args:
-            mock_logger, Mock para el logger.
-            mock_validate_module_registration, Mock de la función de validación de registro.
-            mock_check_missing_dependencies, Mock de la función de chequeo de dependencias.
-            mock_requests, Mock para el módulo `requests`.
+            mock_logger: Mock para el logger.
+            mock_validate_module_registration: Mock de la función de
+                validación de registro.
+            mock_check_missing_dependencies: Mock de la función de chequeo de
+                dependencias.
+            mock_requests: Mock para el módulo `requests`.
         """
         initial_vector = [2.0, 0.0]
         initial_norm = np.linalg.norm(initial_vector)
@@ -1058,10 +1078,12 @@ class TestAgentAI(unittest.TestCase):
         debería reducir la magnitud a un 90% de la original.
 
         Args:
-            mock_logger, Mock para el logger.
-            mock_validate_module_registration, Mock de la función de validación de registro.
-            mock_check_missing_dependencies, Mock de la función de chequeo de dependencias.
-            mock_requests, Mock para el módulo `requests`.
+            mock_logger: Mock para el logger.
+            mock_validate_module_registration: Mock de la función de
+                validación de registro.
+            mock_check_missing_dependencies: Mock de la función de chequeo de
+                dependencias.
+            mock_requests: Mock para el módulo `requests`.
         """
         initial_vector = [5.0, 0.0]
         initial_norm = np.linalg.norm(initial_vector)
@@ -1665,7 +1687,8 @@ class TestAgentAI(unittest.TestCase):
     ):
         """Prueba el análisis de una respuesta PID con la nueva lógica robusta."""
         setpoint = 1.0
-        # 11 data points, so steady state is calculated from the last 10% (last 2 points)
+        # 11 data points, so steady state is calculated from the last 10%
+        # (last 2 points)
         timestamps = [1672531200 + i for i in range(11)]
         values = [0.0, 0.2, 0.5, 0.9, 1.1, 1.2, 1.1, 1.05, 1.02, 1.01, 1.01]
         data = list(zip(timestamps, values, strict=False))
@@ -1674,8 +1697,10 @@ class TestAgentAI(unittest.TestCase):
         # rise time (10% -> 0.101, 90% -> 0.909)
         # time_10 = 1, time_90 = 4. rise_time = 3
         # peak = 1.2. overshoot = (1.2 - 1.01)/1.01 * 100 = 18.81%
-        # settling band [0.9595, 1.0605]. last outside is 1.2 at t=5. settling_time = 5
-        # crossings: 0.0 -> 1.2 (1), 1.2 -> 1.05 (none), 1.05 -> 1.0 (none). 1 crossing. Not oscillatory.
+        # settling band [0.9595, 1.0605]. last outside is 1.2 at t=5.
+        # settling_time = 5
+        # crossings: 0.0 -> 1.2 (1), 1.2 -> 1.05 (none), 1.05 -> 1.0 (none).
+        # 1 crossing. Not oscillatory.
 
         analysis = self.agent.analyze_pid_response(data, setpoint)
 
@@ -1703,7 +1728,8 @@ class TestAgentAI(unittest.TestCase):
         values = [0.0, 1.2, 0.8, 1.1, 0.9, 1.05, 0.95, 1.02, 0.98, 1.01, 1.0]
         data = list(zip(timestamps, values, strict=False))
 
-        # crossings: 0->1.2, 1.2->0.8, 0.8->1.1, 1.1->0.9, 0.9->1.05, 1.05->0.95, 0.95->1.02, 1.02->0.98, 0.98->1.01
+        # crossings: 0->1.2, 1.2->0.8, 0.8->1.1, 1.1->0.9, 0.9->1.05,
+        # 1.05->0.95, 0.95->1.02, 1.02->0.98, 0.98->1.01
         # many crossings.
         analysis = self.agent.analyze_pid_response(data, setpoint)
         self.assertTrue(analysis["oscillatory"])

--- a/tests/unit/test_atomic_piston_v2.py
+++ b/tests/unit/test_atomic_piston_v2.py
@@ -1,3 +1,5 @@
+import csv
+import os
 from unittest.mock import patch
 
 import numpy as np
@@ -12,9 +14,6 @@ DEFAULT_ELASTICITY = 10.0
 DEFAULT_DAMPING = 1.0
 DEFAULT_PISTON_MASS = 1.0
 DT = 0.01  # Time step for updates
-
-import csv
-import os
 
 # Path for patching time.monotonic
 TIME_PATCH_PATH = "atomic_piston.atomic_piston_service.time.monotonic"

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -14,7 +14,8 @@ class TestMeasurePerformanceDecorator(unittest.TestCase):
     @patch("common.decorators.requests.post")
     def test_decorator_sends_metrics_and_preserves_metadata(self, mock_post):
         """
-        Prueba que el decorador envía las métricas correctamente y preserva los metadatos.
+        Prueba que el decorador envía las métricas correctamente y preserva
+        los metadatos.
         """
         agent_ai_url = "http://fake-agent-ai:9000"
 
@@ -52,7 +53,8 @@ class TestMeasurePerformanceDecorator(unittest.TestCase):
     @patch("common.decorators.requests.post")
     def test_call_count_is_correct_across_multiple_calls(self, mock_post):
         """
-        Prueba que el contador de llamadas se incrementa correctamente en llamadas sucesivas.
+        Prueba que el contador de llamadas se incrementa correctamente en
+        llamadas sucesivas.
         """
         agent_ai_url = "http://fake-agent-ai:9000"
 

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -232,33 +232,4 @@ def test_receive_metrics_bad_request(client_and_mocks):
     assert "Payload JSON vacío o ausente" in response.json["mensaje"]
 
 
-def test_receive_metrics_success(client_and_mocks):
-    """Prueba POST /api/metrics exitoso."""
-    client, mock_instance, _ = client_and_mocks
-
-    metric_data = {
-        "source_service": "test_service",
-        "function_name": "test_function",
-        "execution_time": 0.123,
-        "call_count": 5,
-    }
-
-    response = client.post("/api/metrics", json=metric_data)
-
-    mock_instance.store_metric.assert_called_once_with(metric_data)
-    assert response.status_code == 200
-    assert response.json["status"] == "success"
-
-
-def test_receive_metrics_bad_request(client_and_mocks):
-    """Prueba POST /api/metrics con payload vacío."""
-    client, mock_instance, _ = client_and_mocks
-
-    response = client.post("/api/metrics", json=None)
-
-    mock_instance.store_metric.assert_not_called()
-    assert response.status_code == 400
-    assert "Payload JSON vacío o ausente" in response.json["mensaje"]
-
-
 # --- END OF FILE tests/unit/test_endpoints.py ---

--- a/tests/unit/test_harmony_controller.py
+++ b/tests/unit/test_harmony_controller.py
@@ -44,7 +44,7 @@ def task_manager_cleanup():
     """
     # Clean up before the test runs
     with task_manager.lock:
-        for task_id, task_info in list(task_manager.tasks.items()):
+        for _task_id, task_info in list(task_manager.tasks.items()):
             if task_info["thread"].is_alive():
                 task_info["stop_event"].set()
                 task_info["thread"].join(timeout=1)
@@ -55,7 +55,7 @@ def task_manager_cleanup():
     finally:
         # Clean up after the test has run
         with task_manager.lock:
-            for task_id, task_info in list(task_manager.tasks.items()):
+            for _task_id, task_info in list(task_manager.tasks.items()):
                 if task_info["thread"].is_alive():
                     task_info["stop_event"].set()
                     task_info["thread"].join(timeout=1)

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -20,10 +20,10 @@ try:
 except ImportError:
     try:
         import logger as agent_logger
-    except ImportError:
+    except ImportError as e:
         raise ImportError(
             "No se pudo importar el módulo loggerVerifica PYTHONPATH y estructura."
-        )
+        ) from e
 
 logger_instance = logging.getLogger("agent_ai")
 

--- a/tests/unit/test_malla_watcher.py
+++ b/tests/unit/test_malla_watcher.py
@@ -315,7 +315,7 @@ def test_apply_external_field_to_mesh_logic(malla_para_test_aplicar_campo):
     apply_ext_field_func(mesh_instance, external_field_list)
 
     changed_count = 0
-    for coords, cell in mesh_instance.cells.items():
+    for _coords, cell in mesh_instance.cells.items():
         assert isinstance(cell.q_vector, np.ndarray)
         assert cell.q_vector.shape == (2,)
         is_zero_vector = np.array_equal(cell.q_vector, np.zeros(2))
@@ -1442,7 +1442,6 @@ def test_api_malla_influence_push_invalid_payload(client, reset_globals):
     Test: /api/malla/influence (push)
     maneja payloads inválidos.
     """
-    reset_globals
     response_missing_key = client.post(
         "/api/malla/influence", json={"otro_dato": "valor"}
     )

--- a/tests/unit/test_pcb_atomic_piston.py
+++ b/tests/unit/test_pcb_atomic_piston.py
@@ -3,13 +3,11 @@ from unittest.mock import MagicMock, call
 
 # Mock pcbnew and skidl before they are imported by the script under test
 # This is crucial for running tests without KiCad installed
-sys.modules["pcbnew"] = MagicMock()
-sys.modules["skidl"] = MagicMock()
-
-# Now we can import the script to be tested
 from atomic_piston import pcb_atomic_piston_v2
 from atomic_piston.config import BOARD_HEIGHT, BOARD_WIDTH, PLACEMENTS
-from atomic_piston.constants import *
+
+sys.modules["pcbnew"] = MagicMock()
+sys.modules["skidl"] = MagicMock()
 
 
 def test_create_schematic_netlist(mocker):
@@ -126,7 +124,7 @@ def test_place_components(mocker):
 
     # Assert
     mock_wxPointMM.assert_has_calls(expected_pos_calls, any_order=True)
-    for i, (ref, placement) in enumerate(PLACEMENTS.items()):
+    for i, (_ref, placement) in enumerate(PLACEMENTS.items()):
         mock_module = mock_modules[i]
         mock_module.SetPosition.assert_called_once()
         mock_module.SetOrientationDegrees.assert_called_once_with(placement["rot"])

--- a/watcher_security/lia.py
+++ b/watcher_security/lia.py
@@ -44,7 +44,7 @@ class LIATransformer:
             raise ValueError("Dimensionalidad del vector incorrecta")
         transformed = np.dot(self.transformation_matrix, vector)
         # Normalizar por subespacio
-        for name, subspace in self.subspaces.items():
+        for _name, subspace in self.subspaces.items():
             subspace_norm = np.linalg.norm(transformed[subspace])
             if subspace_norm > 0:
                 transformed[subspace] /= subspace_norm

--- a/watchers/watchers_tools/malla_watcher/utils/cilindro_grafenal.py
+++ b/watchers/watchers_tools/malla_watcher/utils/cilindro_grafenal.py
@@ -15,7 +15,8 @@ try:
     from scipy.spatial import cKDTree
 except ImportError:
     logger.warning(
-        "Scipy no está instalado. El rendimiento de la búsqueda de vecinos en Z se verá afectado."
+        "Scipy no está instalado. El rendimiento de la búsqueda de vecinos "
+        "en Z se verá afectado."
     )
     cKDTree = None
 
@@ -301,7 +302,6 @@ class HexCylindricalMesh:
             # La coordenada q se envuelve para manejar la periodicidad
             # circunferencial. Esto asegura que la malla se conecte
             # correctamente alrededor del cilindro.
-            q_for_x_flat = self._wrap_q(q)
 
             x_flat_unwrapped, y_flat_unwrapped = axial_to_cartesian_flat(
                 q, r, self.hex_size


### PR DESCRIPTION
This commit addresses 117 linting errors and style inconsistencies identified by an initial `ruff check .` run.

The changes include:
- Updating the `pyproject.toml` configuration to the new `[tool.ruff.lint]` standard.
- Running `ruff check --fix` and `ruff format` to automatically correct a majority of the issues.
- Manually fixing the remaining errors, including:
  - Undefined names (F821)
  - Unused variables and imports (F841, F401, B007)
  - Incorrect exception chaining (B904)
  - Redefined functions in tests (F811)
  - Star imports (F403)
  - Useless expressions (B018)
  - Manually wrapping long lines in comments and strings (E501).

The codebase is now fully compliant with the defined Ruff rules, with `ruff check .` reporting 0 errors.