### PR TITLE
Fix: Bootstrap pip-tools installation in compile script

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,18 @@ Para poner en marcha el ecosistema de Watchers, necesitarás el siguiente softwa
 
 ## Configuración del Entorno de Desarrollo Local
 
-1.  Crea y activa un entorno virtual.
-2.  Ejecuta el script de compilación: `./scripts/compile_requirements.sh`
-3.  Instala las dependencias de desarrollo: `pip install -r requirements/dev.txt`
+Para trabajar en el proyecto localmente (ejecutar tests, linters, etc.), sigue estos pasos:
+
+1.  **Crea y activa un entorno virtual:**
+    ```bash
+    python3 -m venv watchers_env
+    source watchers_env/bin/activate
+    ```
+
+2.  **Compila e instala todas las dependencias:**
+    *   Este script compilará todos los archivos `requirements.in` a `requirements.txt`.
+    *   Luego, instalará todas las dependencias necesarias para el desarrollo.
+    ```bash
+    ./scripts/compile_requirements.sh
+    pip install -r requirements-dev.txt
+    ```

--- a/scripts/compile_requirements.sh
+++ b/scripts/compile_requirements.sh
@@ -1,19 +1,32 @@
 #!/bin/bash
 set -e
+
+# --- Función de Bootstrap ---
+# Asegura que pip-tools esté instalado para poder ejecutar el script.
+ensure_pip_tools() {
+    if ! command -v pip-compile &> /dev/null; then
+        echo "pip-compile no encontrado. Instalando pip-tools..."
+        python3 -m pip install pip-tools
+    fi
+}
+
+# --- Ejecución Principal ---
 echo "--- Compilando Archivos de Requisitos del Monorepo ---"
 
-# 1. Compilar los requisitos base y de desarrollo en la raíz
+# 1. Asegurar que las herramientas necesarias existan
+ensure_pip_tools
+
+# 2. Compilar los requisitos base y de desarrollo en la raíz
 echo "Compilando requisitos raíz (base y dev)..."
 pip-compile requirements.in -o requirements.txt
 pip-compile requirements-dev.in -o requirements-dev.txt
 
-# 2. Descubrir y compilar los requisitos de cada servicio
-# Usamos find para buscar todos los requirements.in, excluyendo la raíz y el venv
+# 3. Descubrir y compilar los requisitos de cada servicio
+echo "Compilando requisitos de los servicios..."
 find . -path ./requirements.in -prune -o \
        -path ./watchers_env -prune -o \
        -name "requirements.in" -print | while read -r req_in; do
 
-    # Obtener el directorio y el archivo .txt correspondiente
     dir=$(dirname "$req_in")
     req_txt="${req_in%.in}.txt"
 


### PR DESCRIPTION
Modifies the `scripts/compile_requirements.sh` script to prevent a "command not found" error.

The script now includes a bootstrap function that checks if `pip-compile` is available and installs `pip-tools` if it is not.

The `README.md` has been updated to simplify the development setup instructions, as the user no longer needs to manually install `pip-tools` before running the compilation script.